### PR TITLE
Trigger Pending DelayedFetches while producing data

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedCreatePartitions.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedCreatePartitions.java
@@ -42,7 +42,7 @@ class DelayedCreatePartitions extends DelayedOperation {
     }
 
     @Override
-    public boolean tryComplete() {
+    public boolean tryComplete(boolean notify) {
         if (numTopics.get() <= 0) {
             forceComplete();
             return true;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedCreateTopics.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedCreateTopics.java
@@ -42,7 +42,7 @@ class DelayedCreateTopics extends DelayedOperation {
     }
 
     @Override
-    public boolean tryComplete() {
+    public boolean tryComplete(boolean notify) {
         if (numTopics.get() <= 0) {
             forceComplete();
             return true;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedProduceAndFetch.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedProduceAndFetch.java
@@ -42,7 +42,7 @@ class DelayedProduceAndFetch extends DelayedOperation {
     }
 
     @Override
-    public boolean tryComplete() {
+    public boolean tryComplete(boolean notify) {
         if (topicPartitionNum.get() <= 0) {
             forceComplete();
             return true;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -60,7 +60,7 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
     protected AtomicBoolean isActive = new AtomicBoolean(false);
     // Queue to make response get responseFuture in order and limit the max request size
     private final LinkedBlockingQueue<ResponseAndRequest> requestQueue;
-
+    @Getter
     protected final RequestStats requestStats;
     @Getter
     protected final KafkaServiceConfiguration kafkaConfig;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopServerStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopServerStats.java
@@ -75,6 +75,7 @@ public interface KopServerStats {
     String PREPARE_METADATA = "PREPARE_METADATA";
     String MESSAGE_READ = "MESSAGE_READ";
     String FETCH_DECODE = "FETCH_DECODE";
+    String WAITING_FETCHES_TRIGGERED = "WAITING_FETCHES_TRIGGERED";
 
     /**
      * Consumer stats.

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -35,12 +35,14 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.util.MathUtils;
@@ -67,6 +69,7 @@ import org.apache.kafka.common.requests.FetchResponse.PartitionData;
 import org.apache.kafka.common.requests.IsolationLevel;
 import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.requests.ResponseCallbackWrapper;
+import org.apache.kafka.common.utils.SystemTime;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.metadata.api.GetResult;
 
@@ -83,6 +86,7 @@ public final class MessageFetchContext {
     };
 
     private final Handle<MessageFetchContext> recyclerHandle;
+    private long startTime;
     private Map<TopicPartition, PartitionData<MemoryRecords>> responseData;
     private ConcurrentLinkedQueue<DecodeResult> decodeResults;
     private KafkaRequestHandler requestHandler;
@@ -95,7 +99,7 @@ public final class MessageFetchContext {
     private RequestHeader header;
     private volatile CompletableFuture<AbstractResponse> resultFuture;
     private AtomicBoolean hasComplete;
-    private AtomicLong bytesReadable;
+    private AtomicLong bytesRead;
     private DelayedOperationPurgatory<DelayedOperation> fetchPurgatory;
     private String namespacePrefix;
 
@@ -119,8 +123,9 @@ public final class MessageFetchContext {
         context.header = kafkaHeaderAndRequest.getHeader();
         context.resultFuture = resultFuture;
         context.hasComplete = new AtomicBoolean(false);
-        context.bytesReadable = new AtomicLong(0);
+        context.bytesRead = new AtomicLong(0);
         context.fetchPurgatory = fetchPurgatory;
+        context.startTime = SystemTime.SYSTEM.hiResClockMs();;
         return context;
     }
 
@@ -142,6 +147,7 @@ public final class MessageFetchContext {
         context.header = null;
         context.resultFuture = resultFuture;
         context.hasComplete = new AtomicBoolean(false);
+        context.startTime = SystemTime.SYSTEM.hiResClockMs();;
         return context;
     }
 
@@ -163,7 +169,7 @@ public final class MessageFetchContext {
         header = null;
         resultFuture = null;
         hasComplete = null;
-        bytesReadable = null;
+        bytesRead = null;
         fetchPurgatory = null;
         namespacePrefix = null;
         recyclerHandle.recycle(this);
@@ -195,14 +201,47 @@ public final class MessageFetchContext {
     private void tryComplete() {
         if (resultFuture != null && responseData.size() >= fetchRequest.fetchData().size()
                 && hasComplete.compareAndSet(false, true)) {
-            DelayedFetch delayedFetch = new DelayedFetch(fetchRequest.maxWait(), bytesReadable,
-                    fetchRequest.minBytes(), this::complete);
-            List<Object> delayedFetchKeys =
-                    fetchRequest.fetchData().keySet().stream()
-                            .map(DelayedOperationKey.TopicPartitionOperationKey::new).collect(Collectors.toList());
-            fetchPurgatory.tryCompleteElseWatch(delayedFetch, delayedFetchKeys);
+            boolean errorsOccurred = false;
+            if (responseData
+                    .values()
+                    .stream()
+                    .anyMatch(p->p.error != Errors.NONE)) {
+                // if there is an error no need to wait, the fetch must fail
+                // as soon as possible
+                errorsOccurred = true;
+            }
+            long now = SystemTime.SYSTEM.hiResClockMs();
+            long currentWait = now - this.startTime;
+            long remainingMaxWait = fetchRequest.maxWait() - currentWait;
+            long maxWait = Math.min(remainingMaxWait, fetchRequest.maxWait());
+            if (bytesRead.get() < fetchRequest.minBytes() && !errorsOccurred && maxWait > 0) {
+                // we haven't read enough data, need to wait
+                DelayedFetch delayedFetch = new DelayedFetch(maxWait, bytesRead,
+                        fetchRequest.minBytes(), this);
+                List<Object> delayedFetchKeys =
+                        fetchRequest.fetchData().keySet().stream()
+                                .map(DelayedOperationKey.TopicPartitionOperationKey::new).collect(Collectors.toList());
+                fetchPurgatory.tryCompleteElseWatch(delayedFetch, delayedFetchKeys);
+            } else {
+                this.complete();
+            }
         }
     }
+
+    /**
+     * Restart this Fetch, we were waiting for some data (minBytes)
+     * and someone wrote something on any of the watched partitions.
+     */
+    public void onDataWrittenToSomePartition() {
+        decodeResults.forEach(DecodeResult::recycle);
+        decodeResults.clear();
+        bytesRead.set(0);
+        hasComplete.set(false);
+        log.info("onDataWrittenToSomePartition current resposnses {}", responseData);
+        responseData.clear();
+        handleFetch();
+    }
+
 
     public void complete() {
         if (resultFuture == null) {
@@ -329,6 +368,9 @@ public final class MessageFetchContext {
         // the future that is returned by getTopicConsumerManager is always completed normally
         topicManager.getTopicConsumerManager(fullTopicName).thenAccept(tcm -> {
             if (tcm == null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Fetch for {}: failed, topic not owned .", topicPartition);
+                }
                 registerPrepareMetadataFailedEvent(startPrepareMetadataNanos);
                 // remove null future cache
                 KafkaTopicConsumerManagerCache.getInstance().removeAndCloseByTopic(fullTopicName);
@@ -488,7 +530,7 @@ public final class MessageFetchContext {
                     highWatermark, // TODO: should it be changed to the logStartOffset?
                     abortedTransactions,
                     kafkaRecords));
-            bytesReadable.getAndAdd(kafkaRecords.sizeInBytes());
+            bytesRead.getAndAdd(kafkaRecords.sizeInBytes());
             tryComplete();
         });
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
@@ -28,6 +28,7 @@ import static io.streamnative.pulsar.handlers.kop.KopServerStats.REQUEST_QUEUE_S
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.RESPONSE_BLOCKED_LATENCY;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.RESPONSE_BLOCKED_TIMES;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.SERVER_SCOPE;
+import static io.streamnative.pulsar.handlers.kop.KopServerStats.WAITING_FETCHES_TRIGGERED;
 
 import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -112,6 +113,12 @@ public class RequestStats {
     )
     private final OpStatsLogger fetchDecodeStats;
 
+    @StatsDoc(
+            name = WAITING_FETCHES_TRIGGERED,
+            help = "number of pending fetches that woke up due to some data produced"
+    )
+    private final Counter waitingFetchesTriggered;
+
     public RequestStats(StatsLogger statsLogger) {
         this.statsLogger = statsLogger;
 
@@ -127,6 +134,7 @@ public class RequestStats {
         this.prepareMetadataStats = statsLogger.getOpStatsLogger(PREPARE_METADATA);
         this.messageReadStats = statsLogger.getOpStatsLogger(MESSAGE_READ);
         this.fetchDecodeStats  = statsLogger.getOpStatsLogger(FETCH_DECODE);
+        this.waitingFetchesTriggered = statsLogger.getCounter(WAITING_FETCHES_TRIGGERED);
 
         statsLogger.registerGauge(REQUEST_QUEUE_SIZE, new Gauge<Number>() {
             @Override

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/DelayedHeartbeat.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/DelayedHeartbeat.java
@@ -51,7 +51,7 @@ class DelayedHeartbeat extends DelayedOperation {
     }
 
     @Override
-    public boolean tryComplete() {
+    public boolean tryComplete(boolean notify) {
         return coordinator.tryCompleteHeartbeat(group, member, heartbeatDeadline, () -> forceComplete());
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/DelayedJoin.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/DelayedJoin.java
@@ -50,7 +50,7 @@ class DelayedJoin extends DelayedOperation {
     }
 
     @Override
-    public boolean tryComplete() {
+    public boolean tryComplete(boolean notify) {
         return coordinator.tryCompleteJoin(group, () -> forceComplete());
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/InitialDelayedJoin.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/InitialDelayedJoin.java
@@ -74,7 +74,7 @@ class InitialDelayedJoin extends DelayedJoin {
     }
 
     @Override
-    public boolean tryComplete() {
+    public boolean tryComplete(boolean notify) {
         return false;
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/delayed/DelayedOperation.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/delayed/DelayedOperation.java
@@ -96,7 +96,7 @@ public abstract class DelayedOperation extends TimerTask {
      *
      * <p>This function needs to be defined in subclasses.
      */
-    public abstract boolean tryComplete();
+    public abstract boolean tryComplete(boolean notify);
 
     /**
      * Thread-safe variant of tryComplete() that attempts completion only if the lock can be acquired
@@ -110,14 +110,14 @@ public abstract class DelayedOperation extends TimerTask {
      * every invocation of `maybeTryComplete` is followed by at least one invocation of `tryComplete` until
      * the operation is actually completed.
      */
-    boolean maybeTryComplete() {
+    boolean maybeTryComplete(boolean notify) {
         boolean retry = false;
         boolean done = false;
         do {
             if (lock.tryLock()) {
                 try {
                     tryCompletePending.set(false);
-                    done = tryComplete();
+                    done = tryComplete(notify);
                 } finally {
                     lock.unlock();
                 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/delayed/DelayedOperationPurgatory.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/delayed/DelayedOperationPurgatory.java
@@ -175,7 +175,7 @@ public class DelayedOperationPurgatory<T extends DelayedOperation> {
 
         // At this point the only thread that can attempt this operation is this current thread
         // Hence it is safe to tryComplete() without a lock
-        boolean isCompletedByMe = operation.tryComplete();
+        boolean isCompletedByMe = operation.tryComplete(false);
         if (isCompletedByMe) {
             return true;
         }
@@ -194,7 +194,7 @@ public class DelayedOperationPurgatory<T extends DelayedOperation> {
             }
         }
 
-        isCompletedByMe = operation.maybeTryComplete();
+        isCompletedByMe = operation.maybeTryComplete(false);
         if (isCompletedByMe) {
             return true;
         }
@@ -349,7 +349,7 @@ public class DelayedOperationPurgatory<T extends DelayedOperation> {
                 if (curr.isCompleted()) {
                     // another thread has completed this operation, just remove it
                     iter.remove();
-                } else if (curr.maybeTryComplete()) {
+                } else if (curr.maybeTryComplete(true)) {
                     iter.remove();
                     completed += 1;
                 }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/delayed/DelayedOperationTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/delayed/DelayedOperationTest.java
@@ -92,7 +92,7 @@ public class DelayedOperationTest {
         }
 
         @Override
-        public boolean tryComplete() {
+        public boolean tryComplete(boolean notify) {
             if (completable) {
                 return forceComplete();
             } else {
@@ -120,7 +120,7 @@ public class DelayedOperationTest {
 
         @SneakyThrows
         @Override
-        public boolean tryComplete() {
+        public boolean tryComplete(boolean notify) {
             boolean shouldComplete = completable;
             Thread.sleep(ThreadLocalRandom.current().nextInt(maxDelayMs));
             if (shouldComplete) {
@@ -225,13 +225,13 @@ public class DelayedOperationTest {
 
         // complete the operations, it should immediately be purged from the delayed operation
         r2.completable = true;
-        r2.tryComplete();
+        r2.tryComplete(false);
         assertEquals(
             "Purgatory should have 2 total delayed operations instead of " + purgatory.delayed(),
             2, purgatory.delayed());
 
         r3.completable = true;
-        r3.tryComplete();
+        r3.tryComplete(false);
         assertEquals(
             "Purgatory should have 1 total delayed operations instead of " + purgatory.delayed(),
             1, purgatory.delayed());
@@ -285,7 +285,7 @@ public class DelayedOperationTest {
         MockDelayedOperation op = new MockDelayedOperation(100000L) {
             @SneakyThrows
             @Override
-            public boolean tryComplete() {
+            public boolean tryComplete(boolean notify) {
                 boolean shouldComplete = completionAttemptsRemaining.decrementAndGet() <= 0;
                 tryCompleteSemaphore.acquire();
                 try {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
@@ -122,7 +122,7 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
         kafkaConsumer2.close();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 60000)
     public void testPollEmptyTopic() throws Exception {
         int partitionNumber = 50;
         String kafkaTopic = "kopPollEmptyTopic" + partitionNumber;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -234,7 +234,7 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
     }
 
      // Unit test {@link GroupCoordinator}.
-    @Test(timeOut = 30000)
+    @Test(timeOut = 60000)
     public void testMutiBrokerAndCoordinator() throws Exception {
         int partitionNumber = 10;
         String kafkaTopicName = "kopMutiBrokerAndCoordinator" + partitionNumber;
@@ -371,7 +371,7 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
     }
 
     // Unit test for unload / reload user topic bundle, verify it works well.
-    @Test(timeOut = 30000)
+    @Test(timeOut = 60000)
     public void testMultiBrokerUnloadReload() throws Exception {
         int partitionNumber = 10;
         String kafkaTopicName = "kopMultiBrokerUnloadReload" + partitionNumber;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -29,14 +29,19 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
 import io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder.KafkaHeaderAndRequest;
+import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -46,7 +51,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -380,17 +390,21 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
         int maxWaitMs = 3000;
         int minBytes = 1;
         // case1: consuming an empty topic.
+        @Cleanup
         KafkaConsumer<String, String> consumer1 = createKafkaConsumer(maxWaitMs, minBytes);
         consumer1.assign(topicPartitions);
         Long startTime1 = System.currentTimeMillis();
-        consumer1.poll(Duration.ofMillis(maxWaitMs));
+        ConsumerRecords<String, String> emptyResult = consumer1.poll(Duration.ofMillis(maxWaitMs));
         Long endTime1 = System.currentTimeMillis();
         log.info("cost time1:" + (endTime1 - startTime1));
+        assertEquals(0, emptyResult.count());
 
         // case2: consuming an topic after producing data.
+        @Cleanup
         KafkaProducer<String, String> kProducer = createKafkaProducer();
         produceData(kProducer, topicPartitions, 10);
 
+        @Cleanup
         KafkaConsumer<String, String> consumer2 = createKafkaConsumer(maxWaitMs, minBytes);
         consumer2.assign(topicPartitions);
         consumer2.seekToBeginning(topicPartitions);
@@ -405,6 +419,57 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
         // When the amount of readable data is not less than minBytes,
         // the time-consuming is usually less than maxWait time.
         assertTrue(endTime2 - startTime2 < maxWaitMs);
+    }
+
+    /**
+     * Test the sending speed of fetch request when the readable data is less than fetch.minBytes.
+     */
+    @Test(timeOut = 60000)
+    public void testFetchMinBytesSingleConsumer() throws Exception {
+        String topicName = "testMinBytesTopic";
+        TopicPartition tp = new TopicPartition(topicName, 0);
+
+        // create partitioned topic.
+        admin.topics().createPartitionedTopic(topicName, 1);
+        List<TopicPartition> topicPartitions = new ArrayList<>();
+        topicPartitions.add(tp);
+
+        int maxWaitMs = 3000; // very long time
+        int minBytes = 1;
+        // case1: consuming an empty topic.
+        @Cleanup
+        KafkaConsumer<String, String> consumer1 = createKafkaConsumer(maxWaitMs, minBytes);
+        consumer1.assign(topicPartitions);
+        ConsumerRecords<String, String> emptyResult = consumer1.poll(Duration.ofMillis(maxWaitMs));
+        assertEquals(0, emptyResult.count());
+
+        // case2: consuming an topic after producing data.
+        @Cleanup
+        KafkaProducer<String, String> kProducer = createKafkaProducer();
+        produceData(kProducer, topicPartitions, 10);
+
+        int totalRead = 0;
+        do {
+            // Consumer1 is able to eventually read the data
+            // please note that we are passing 100 as max pool time
+            ConsumerRecords<String, String> goodResultFrom1 = consumer1.poll(Duration.ofMillis(100));
+            totalRead += goodResultFrom1.count();
+            log.info("read {} records totalRead {}", goodResultFrom1.count(), totalRead);
+            // we require that every pool returns at least one record
+            // that is that we NEVER hit the maxWait timeout and also the pool timeout
+            assertTrue(goodResultFrom1.count() > 0);
+        } while (totalRead < 10);
+        assertEquals(10, totalRead);
+
+
+        HttpClient httpClient = HttpClientBuilder.create().build();
+        final String metricsEndPoint = pulsar.getWebServiceAddress() + "/metrics";
+        HttpResponse response = httpClient.execute(new HttpGet(metricsEndPoint));
+        InputStream inputStream = response.getEntity().getContent();
+        String metrics = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+        log.info("metrics {}", metrics);
+
+        assertTrue(metrics.contains("kop_server_WAITING_FETCHES_TRIGGERED 1"));
     }
 
     @Test(timeOut = 80000)


### PR DESCRIPTION
Changes:
- do not schedule a DelayedFetch is we already read enough data (save memory allocations and CPU during high load cases)
- On the Produce path, trigger any pending DelayedFetch that is waiting for messages to be produced
- When a DelayedFetch is triggered, restart the Fetch from scratch

This patch works well with the default configuration of the Kafka client, with fetch.min.bytes=1.
If you have a greater number of fetch.min.bytes and there is low traffic on the topic the pending Fetch may be restarted many times, triggering more reads from BookKeeper.

But the default configuration of the Kafka client is fetch.min.bytes is 1 and it is unusual to see it modified.