### PR TITLE
[EXPERIMENTAL] Consumer Offsets: add ability to not wait for fsync

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -702,6 +702,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             .maxMetadataSize(kafkaConfig.getOffsetMetadataMaxSize())
             .offsetsRetentionCheckIntervalMs(kafkaConfig.getOffsetsRetentionCheckIntervalMs())
             .offsetsRetentionMs(TimeUnit.MINUTES.toMillis(kafkaConfig.getOffsetsRetentionMinutes()))
+            .offsetsSync(kafkaConfig.isOffsetsWaitForSync())
             .build();
 
         GroupCoordinator groupCoordinator = GroupCoordinator.of(

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -193,6 +193,12 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_KOP,
+            doc = "Wait for durable write while committing group offsets"
+    )
+    private boolean offsetsWaitForSync = true;
+
+    @FieldContext(
+            category = CATEGORY_KOP,
             doc = "Zookeeper path for storing kop consumer group"
     )
     private String groupIdZooKeeperPath = "/client_group_id";

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -238,7 +238,6 @@ public final class MessageFetchContext {
         decodeResults.clear();
         bytesRead.set(0);
         hasComplete.set(false);
-        log.info("onDataWrittenToSomePartition current resposnses {}", responseData);
         responseData.clear();
         handleFetch();
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/OffsetConfig.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/OffsetConfig.java
@@ -48,4 +48,6 @@ public class OffsetConfig {
     private long offsetsRetentionCheckIntervalMs = DefaultOffsetsRetentionCheckIntervalMs;
     @Default
     private int offsetsTopicNumPartitions = DefaultOffsetsNumPartitions;
+    @Default
+    private boolean offsetsSync = true;
 }


### PR DESCRIPTION
Commit Offsets latency is bounded by the write latency of sending a message to Pulsar.

This patch adds a new parameter `offsetsWaitForSync`, if you set it to `false` then the Commit Offsets API will not wait for Pulsar to store the message before sending the confirmation back to the client.

This configuration will give best results for the Kafka client, but it is very dangerous of course