### PR TITLE
Fetch: do not decode data in critical BookKeeper OrderedExecutor thread

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -73,6 +73,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -2623,4 +2624,14 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             throw new AuthenticationException("Internal error while verifying tenant access:" + err, err);
         }
     }
+
+    /**
+     * Return the threadpool that executes the conversion of data during Fetches.
+     * We don't want to decode data inside the critical threads like the ManagedLedger Ordered Executor threads.
+     * @return a executor.
+     */
+    public Executor getDecodeExecutor() {
+        return this.executor;
+    }
+
 }


### PR DESCRIPTION
**Motivation**
During OMB testing @dave2wave noticed that the BookKeeperClientScheduler-OrderedScheduler-X-Y thread pool is busy in doing decoding work (from Pulsar -> Kafka) and this is something that may limit the efficiency of the system because that threadpool handles all the BookKeeper activities.

**Modifications**
With this patch we are performing the "decoding" from Pulsar -> Kafka (con the consumer code path) in a threadpool that is not the BookKeeper Ordered Executor pool (BookKeeperClientScheduler-OrderedScheduler-X-Y).

This is only a proof-of-concept patch, we should probably create a dedicated and tunable threadpool for this activity