### PR TITLE
Add support for TLS only brokers

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -306,6 +306,12 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     private String kopSslKeystoreType = "JKS";
 
     @FieldContext(
+            category = CATEGORY_KOP_SSL,
+            doc = "Use TLS while connecting to other brokers"
+    )
+    private boolean kopTlsEnabledWithBroker = false;
+
+    @FieldContext(
         category = CATEGORY_KOP_SSL,
         doc = "Kafka ssl configuration map with: SSL_KEYSTORE_LOCATION_CONFIG = \"ssl.keystore.location\""
     )

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -138,7 +138,7 @@ public class TransactionCoordinator {
         return new TransactionCoordinator(
                 transactionConfig,
                 new TransactionMarkerChannelManager(tenant, kafkaConfig, transactionStateManager,
-                        kopBrokerLookupManager, false, namespacePrefixForUserTopics,
+                        kopBrokerLookupManager, kafkaConfig.isKopTlsEnabledWithBroker(), namespacePrefixForUserTopics,
                         scheduler),
                 scheduler,
                 producerIdManager,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
@@ -20,6 +20,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
 import io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
@@ -20,8 +20,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
 import io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelInitializer.java
@@ -31,7 +31,7 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 public class TransactionMarkerChannelInitializer extends ChannelInitializer<SocketChannel> {
 
     private final boolean enableTls;
-    private final SslContextFactory.Server sslContextFactory;
+    private final SslContextFactory.Client sslContextFactory;
     private final TransactionMarkerChannelManager transactionMarkerChannelManager;
 
     public TransactionMarkerChannelInitializer(KafkaServiceConfiguration kafkaConfig,
@@ -40,7 +40,7 @@ public class TransactionMarkerChannelInitializer extends ChannelInitializer<Sock
         this.enableTls = enableTls;
         this.transactionMarkerChannelManager = transactionMarkerChannelManager;
         if (enableTls) {
-            sslContextFactory = SSLUtils.createSslContextFactory(kafkaConfig);
+            sslContextFactory = SSLUtils.createClientSslContextFactory(kafkaConfig);
         } else {
             sslContextFactory = null;
         }
@@ -49,7 +49,8 @@ public class TransactionMarkerChannelInitializer extends ChannelInitializer<Sock
     @Override
     protected void initChannel(SocketChannel ch) throws Exception {
         if (this.enableTls) {
-            ch.pipeline().addLast(TLS_HANDLER, new SslHandler(SSLUtils.createSslEngine(sslContextFactory)));
+            ch.pipeline().addLast(TLS_HANDLER,
+                    new SslHandler(SSLUtils.createClientSslEngine(sslContextFactory)));
         }
         ch.pipeline().addLast(new LengthFieldPrepender(4));
         ch.pipeline().addLast("frameDecoder",

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ssl/SSLUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ssl/SSLUtils.java
@@ -257,4 +257,83 @@ public class SSLUtils {
         return engine;
     }
 
+    public static SSLEngine createClientSslEngine(SslContextFactory.Client sslContextFactory) throws Exception {
+        sslContextFactory.start();
+        SSLEngine engine  = sslContextFactory.newSSLEngine();
+        engine.setUseClientMode(true);
+
+        return engine;
+    }
+
+    public static SslContextFactory.Client createClientSslContextFactory(
+            KafkaServiceConfiguration kafkaServiceConfiguration) {
+        Builder<String, Object> sslConfigValues = ImmutableMap.builder();
+
+        CONFIG_NAME_MAP.forEach((key, value) -> {
+            Object obj = null;
+            switch(key) {
+                case SslConfigs.SSL_PROTOCOL_CONFIG:
+                    obj = kafkaServiceConfiguration.getKopSslProtocol();
+                    break;
+                case SslConfigs.SSL_PROVIDER_CONFIG:
+                    obj = kafkaServiceConfiguration.getKopSslProvider();
+                    break;
+                case SslConfigs.SSL_CIPHER_SUITES_CONFIG:
+                    // this obj is Set<String>
+                    obj = kafkaServiceConfiguration.getKopSslCipherSuites();
+                    break;
+                case SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG:
+                    obj = kafkaServiceConfiguration.getKopSslEnabledProtocols();
+                    break;
+                case SslConfigs.SSL_KEYSTORE_TYPE_CONFIG:
+                    obj = kafkaServiceConfiguration.getKopSslKeystoreType();
+                    break;
+                case SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG:
+                    obj = kafkaServiceConfiguration.getKopSslKeystoreLocation();
+                    break;
+                case SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG:
+                    obj = kafkaServiceConfiguration.getKopSslKeystorePassword();
+                    break;
+                case SslConfigs.SSL_KEY_PASSWORD_CONFIG:
+                    obj = kafkaServiceConfiguration.getKopSslKeyPassword();
+                    break;
+                case SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG:
+                    obj = kafkaServiceConfiguration.getKopSslTruststoreType();
+                    break;
+                case SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG:
+                    obj = kafkaServiceConfiguration.getKopSslTruststoreLocation();
+                    break;
+                case SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG:
+                    obj = kafkaServiceConfiguration.getKopSslTruststorePassword();
+                    break;
+                case SslConfigs.SSL_KEYMANAGER_ALGORITHM_CONFIG:
+                    obj = kafkaServiceConfiguration.getKopSslKeymanagerAlgorithm();
+                    break;
+                case SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG:
+                    obj = kafkaServiceConfiguration.getKopSslTrustmanagerAlgorithm();
+                    break;
+                case SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG:
+                    obj = kafkaServiceConfiguration.getKopSslSecureRandomImplementation();
+                    break;
+                case BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG:
+                    obj = kafkaServiceConfiguration.getKopSslClientAuth();
+                    break;
+                default:
+                    log.error("key {} not contained in KafkaServiceConfiguration", key);
+            }
+            if (obj != null) {
+                sslConfigValues.put(key, obj);
+            }
+        });
+        return createClientSslContextFactory(sslConfigValues.build());
+    }
+
+    public static SslContextFactory.Client createClientSslContextFactory(Map<String, Object> sslConfigValues) {
+        SslContextFactory.Client ssl = new SslContextFactory.Client();
+        configureSslContextFactoryTrustStore(ssl, sslConfigValues);
+        configureSslContextFactoryAlgorithms(ssl, sslConfigValues);
+        ssl.setEndpointIdentificationAlgorithm(null);
+        return ssl;
+    }
+
 }

--- a/proxy/src/main/java/io/streamnative/pulsar/handlers/kop/ConnectionToBroker.java
+++ b/proxy/src/main/java/io/streamnative/pulsar/handlers/kop/ConnectionToBroker.java
@@ -13,6 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
+import static io.streamnative.pulsar.handlers.kop.KafkaProtocolHandler.TLS_HANDLER;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.netty.bootstrap.Bootstrap;
@@ -31,6 +32,8 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
+import io.netty.handler.ssl.SslHandler;
+import io.streamnative.pulsar.handlers.kop.utils.ssl.SSLUtils;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.AbstractMap;
@@ -54,6 +57,7 @@ import org.apache.kafka.common.requests.SaslHandshakeRequest;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 @Slf4j
 class ConnectionToBroker {
@@ -66,6 +70,8 @@ class ConnectionToBroker {
     private final ConcurrentHashMap<Integer, PendingAction> pendingRequests = new ConcurrentHashMap<>();
     private volatile boolean closed;
     private CompletableFuture<Channel> connectionFuture;
+    private final SslContextFactory.Client sslContextFactory;
+    private boolean enableTls;
 
     ConnectionToBroker(KafkaProxyRequestHandler kafkaProxyRequestHandler, String connectionKey, String brokerHost,
                        int brokerPort) {
@@ -73,6 +79,13 @@ class ConnectionToBroker {
         this.connectionKey = connectionKey;
         this.brokerHost = brokerHost;
         this.brokerPort = brokerPort;
+        KafkaServiceConfiguration kafkaConfig = kafkaProxyRequestHandler.getKafkaConfig();
+        this.enableTls = kafkaConfig.isKopTlsEnabledWithBroker();
+        if (this.enableTls) {
+            sslContextFactory = SSLUtils.createClientSslContextFactory(kafkaConfig);
+        } else {
+            sslContextFactory = null;
+        }
     }
 
     private synchronized CompletableFuture<Channel> ensureConnection() {
@@ -97,6 +110,9 @@ class ConnectionToBroker {
         b.handler(new ChannelInitializer<SocketChannel>() {
             @Override
             public void initChannel(SocketChannel ch) throws Exception {
+                if (enableTls) {
+                    ch.pipeline().addLast(TLS_HANDLER, new SslHandler(SSLUtils.createClientSslEngine(sslContextFactory)));
+                }
                 ch.pipeline().addLast(new LengthFieldPrepender(4));
                 ch.pipeline().addLast("frameDecoder",
                         new LengthFieldBasedFrameDecoder(KafkaProxyChannelInitializer.MAX_FRAME_LENGTH, 0, 4, 0, 4));

--- a/proxy/src/main/java/io/streamnative/pulsar/handlers/kop/ConnectionToBroker.java
+++ b/proxy/src/main/java/io/streamnative/pulsar/handlers/kop/ConnectionToBroker.java
@@ -111,7 +111,8 @@ class ConnectionToBroker {
             @Override
             public void initChannel(SocketChannel ch) throws Exception {
                 if (enableTls) {
-                    ch.pipeline().addLast(TLS_HANDLER, new SslHandler(SSLUtils.createClientSslEngine(sslContextFactory)));
+                    ch.pipeline().addLast(TLS_HANDLER,
+                            new SslHandler(SSLUtils.createClientSslEngine(sslContextFactory)));
                 }
                 ch.pipeline().addLast(new LengthFieldPrepender(4));
                 ch.pipeline().addLast("frameDecoder",

--- a/proxy/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolProxyMain.java
+++ b/proxy/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolProxyMain.java
@@ -320,8 +320,13 @@ public class KafkaProtocolProxyMain {
             } else {
                 res = rawServiceUrl.substring(0, colon + 1) + kafkaConfig.getKopSchemaRegistryPort();
             }
-            // no https to talk with the internal KOP broker
-            res = res.replace("http://", "http://");
+            // no https to talk with the internal KOP broker by default
+            res = res.replace("https://", "http://");
+
+            // force using HTTPs
+            if (kafkaConfig.isKopTlsEnabledWithBroker()) {
+                res = res.replace("http://", "https://");
+            }
             log.info("SchemaRegistry mapping {} to {}", rawServiceUrl, res);
             return res;
         }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -137,7 +137,7 @@ public abstract class KopProtocolHandlerTestBase {
     protected String restConnect;
     protected boolean enableBrokerEntryMetadata = true;
 
-    private String entryFormat;
+    protected String entryFormat;
 
     protected static final String PLAINTEXT_PREFIX = SecurityProtocol.PLAINTEXT.name() + "://";
     protected static final String SSL_PREFIX = SecurityProtocol.SSL.name() + "://";

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOauthKopHandlersTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOauthKopHandlersTest.java
@@ -30,7 +30,6 @@ import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import javax.security.auth.login.LoginException;
-import lombok.Cleanup;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;


### PR DESCRIPTION
Modifications:
- add new flag kopTlsEnabledWithBroker (named after tlsEnabledWithBroker in Pulsar proxy) to tell KOP to always use TLS while connecting to KOP brokers
- this applies to Transactions
- this applies to the Kafka Proxy

Please note that using the broker advertised listeners and connect to the TLS endpoint is not doable:
- This is not doable on the Proxy because in the proxy cannot do discovery without ZooKeeper
- This won't work well on KOP because a broker may have multiple listeners and a flag to require to connect only by using TLS is needed in any case

