### PR TITLE
Feature: auto-register AVRO schema id while serving Fetch (kafkaApplyAvroSchemaOnDecode)

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
@@ -22,10 +22,12 @@ import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateHandler;
+import io.streamnative.pulsar.handlers.kop.format.SchemaManager;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperation;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationPurgatory;
 import io.streamnative.pulsar.handlers.kop.utils.ssl.SSLUtils;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import lombok.Getter;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.pulsar.broker.PulsarService;
@@ -48,7 +50,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
     private final KopBrokerLookupManager kopBrokerLookupManager;
     @Getter
     private final KafkaTopicManagerSharedState kafkaTopicManagerSharedState;
-    private final SchemaRegistryManager schemaRegistryManager;
+    private final Function<String, SchemaManager> schemaManagerForTenant;
 
     private final AdminManager adminManager;
     private DelayedOperationPurgatory<DelayedOperation> producePurgatory;
@@ -77,9 +79,9 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                                    RequestStats requestStats,
                                    OrderedScheduler sendResponseScheduler,
                                    KafkaTopicManagerSharedState kafkaTopicManagerSharedState,
-                                   SchemaRegistryManager schemaRegistryManager) {
+                                   Function<String, SchemaManager> schemaManagerForTenant) {
         super();
-        this.schemaRegistryManager = schemaRegistryManager;
+        this.schemaManagerForTenant = schemaManagerForTenant;
         this.pulsarService = pulsarService;
         this.kafkaConfig = kafkaConfig;
         this.tenantContextManager = tenantContextManager;
@@ -123,7 +125,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                 tenantContextManager, kopBrokerLookupManager, adminManager,
                 producePurgatory, fetchPurgatory,
                 enableTls, advertisedEndPoint, skipMessagesWithoutIndex, requestStats, sendResponseScheduler,
-                kafkaTopicManagerSharedState, schemaRegistryManager);
+                kafkaTopicManagerSharedState, schemaManagerForTenant);
     }
 
     @VisibleForTesting
@@ -133,7 +135,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                 producePurgatory, fetchPurgatory,
                 enableTls, advertisedEndPoint, skipMessagesWithoutIndex, RequestStats.NULL_INSTANCE,
                 sendResponseScheduler,
-                kafkaTopicManagerSharedState, schemaRegistryManager);
+                kafkaTopicManagerSharedState, schemaManagerForTenant);
     }
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
@@ -48,6 +48,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
     private final KopBrokerLookupManager kopBrokerLookupManager;
     @Getter
     private final KafkaTopicManagerSharedState kafkaTopicManagerSharedState;
+    private final SchemaRegistryManager schemaRegistryManager;
 
     private final AdminManager adminManager;
     private DelayedOperationPurgatory<DelayedOperation> producePurgatory;
@@ -75,8 +76,10 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                                    boolean skipMessagesWithoutIndex,
                                    RequestStats requestStats,
                                    OrderedScheduler sendResponseScheduler,
-                                   KafkaTopicManagerSharedState kafkaTopicManagerSharedState) {
+                                   KafkaTopicManagerSharedState kafkaTopicManagerSharedState,
+                                   SchemaRegistryManager schemaRegistryManager) {
         super();
+        this.schemaRegistryManager = schemaRegistryManager;
         this.pulsarService = pulsarService;
         this.kafkaConfig = kafkaConfig;
         this.tenantContextManager = tenantContextManager;
@@ -120,7 +123,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                 tenantContextManager, kopBrokerLookupManager, adminManager,
                 producePurgatory, fetchPurgatory,
                 enableTls, advertisedEndPoint, skipMessagesWithoutIndex, requestStats, sendResponseScheduler,
-                kafkaTopicManagerSharedState);
+                kafkaTopicManagerSharedState, schemaRegistryManager);
     }
 
     @VisibleForTesting
@@ -130,7 +133,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                 producePurgatory, fetchPurgatory,
                 enableTls, advertisedEndPoint, skipMessagesWithoutIndex, RequestStats.NULL_INSTANCE,
                 sendResponseScheduler,
-                kafkaTopicManagerSharedState);
+                kafkaTopicManagerSharedState, schemaRegistryManager);
     }
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -103,6 +103,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     private OrderedScheduler sendResponseScheduler;
     private NamespaceBundleOwnershipListenerImpl bundleListener;
 
+    @Getter
     private SchemaRegistryManager schemaRegistryManager;
 
     private final Map<String, GroupCoordinator> groupCoordinatorsByTenant = new ConcurrentHashMap<>();
@@ -406,7 +407,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 kafkaConfig.isSkipMessagesWithoutIndex(),
                 requestStats,
                 sendResponseScheduler,
-                kafkaTopicManagerSharedState);
+                kafkaTopicManagerSharedState,
+                schemaRegistryManager);
     }
 
     // this is called after initialize, and with kafkaConfig, brokerService all set.

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -81,7 +81,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     private PrometheusMetricsProvider statsProvider;
     @Getter
     private KopBrokerLookupManager kopBrokerLookupManager;
-    private PulsarAdmin pulsarAdmin;
+    private volatile PulsarAdmin pulsarAdmin;
     @VisibleForTesting
     @Getter
     private AdminManager adminManager = null;
@@ -224,7 +224,6 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
 
         brokerService = service;
         kafkaTopicManagerSharedState = new KafkaTopicManagerSharedState(brokerService);
-        PulsarAdmin pulsarAdmin;
         try {
             pulsarAdmin = brokerService.getPulsar().getAdminClient();
             adminManager = new AdminManager(pulsarAdmin, kafkaConfig);
@@ -423,7 +422,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 requestStats,
                 sendResponseScheduler,
                 kafkaTopicManagerSharedState,
-                schemaRegistryManager);
+                schemaManagerForTenant);
     }
 
     // this is called after initialize, and with kafkaConfig, brokerService all set.

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -180,7 +180,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
 
         if (kafkaConfig.isKafkaApplyAvroSchemaOnDecode()
                 && !kafkaConfig.isKopSchemaRegistryEnable()) {
-            throw new RuntimeException("You myst enable the SchemaRegistry "
+            throw new RuntimeException("You must enable the SchemaRegistry "
                     + "if you want to use kafkaApplyAvroSchemaOnDecode feature");
         }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -33,6 +33,8 @@ import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCo
 import io.streamnative.pulsar.handlers.kop.exceptions.KoPTopicException;
 import io.streamnative.pulsar.handlers.kop.format.EntryFormatter;
 import io.streamnative.pulsar.handlers.kop.format.EntryFormatterFactory;
+import io.streamnative.pulsar.handlers.kop.format.PulsarAdminSchemaManager;
+import io.streamnative.pulsar.handlers.kop.format.SchemaManager;
 import io.streamnative.pulsar.handlers.kop.offset.OffsetAndMetadata;
 import io.streamnative.pulsar.handlers.kop.offset.OffsetMetadata;
 import io.streamnative.pulsar.handlers.kop.security.SaslAuthenticator;
@@ -185,6 +187,7 @@ import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 public class KafkaRequestHandler extends KafkaCommandDecoder {
     private static final String POLICY_ROOT = "/admin/policies/";
 
+    private final SchemaRegistryManager schemaRegistryManager;
     private final PulsarService pulsarService;
     private final KafkaTopicManager topicManager;
     private final TenantContextManager tenantContextManager;
@@ -294,8 +297,10 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                boolean skipMessagesWithoutIndex,
                                RequestStats requestStats,
                                OrderedScheduler sendResponseScheduler,
-                               KafkaTopicManagerSharedState kafkaTopicManagerSharedState) throws Exception {
+                               KafkaTopicManagerSharedState kafkaTopicManagerSharedState,
+                               SchemaRegistryManager schemaRegistryManager) throws Exception {
         super(requestStats, kafkaConfig, sendResponseScheduler);
+        this.schemaRegistryManager = schemaRegistryManager;
         this.pulsarService = pulsarService;
         this.tenantContextManager = tenantContextManager;
         this.kopBrokerLookupManager = kopBrokerLookupManager;
@@ -2601,4 +2606,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         return this.executor;
     }
 
+    public SchemaManager getSchemaManager() {
+        return new PulsarAdminSchemaManager(getCurrentTenant(), getAdmin(),
+                this.schemaRegistryManager.getSchemaStorage());
+    }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -404,6 +404,12 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     private String entryFormat = "pulsar";
 
     @FieldContext(
+            category = CATEGORY_KOP,
+            doc = "Encode the Fetch results using KafkaAvroDeserializer format in case of AVRO data written by Pulsar"
+    )
+    private boolean applyAvroSchemaOnDecode = false;
+
+    @FieldContext(
         category = CATEGORY_KOP,
         doc = "The broker id, default is 1"
     )

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -407,7 +407,7 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
             category = CATEGORY_KOP,
             doc = "Encode the Fetch results using KafkaAvroDeserializer format in case of AVRO data written by Pulsar"
     )
-    private boolean applyAvroSchemaOnDecode = false;
+    private boolean kafkaApplyAvroSchemaOnDecode = false;
 
     @FieldContext(
         category = CATEGORY_KOP,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -22,6 +22,7 @@ import io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder.KafkaHeaderAndReq
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
 import io.streamnative.pulsar.handlers.kop.exceptions.MetadataCorruptedException;
 import io.streamnative.pulsar.handlers.kop.format.DecodeResult;
+import io.streamnative.pulsar.handlers.kop.format.SchemaManager;
 import io.streamnative.pulsar.handlers.kop.security.auth.Resource;
 import io.streamnative.pulsar.handlers.kop.security.auth.ResourceType;
 import io.streamnative.pulsar.handlers.kop.storage.PartitionLog;
@@ -471,41 +472,45 @@ public final class MessageFetchContext {
                 });
 
         // this part is heavyweight, and we should not execute in the ManagedLedger Ordered executor thread
-        groupNameFuture.whenCompleteAsync((groupName, ex) -> {
+        groupNameFuture.whenCompleteAsync((_groupName, ex) -> {
             if (ex != null) {
                 log.error("Get groupId failed.", ex);
-                groupName = "";
+                _groupName = "";
             }
 
-
+            final String groupName = _groupName;
             final long startDecodingEntriesNanos = MathUtils.nowInNano();
-            final DecodeResult decodeResult = requestHandler
-                    .getEntryFormatter().decode(entries, magic);
-            requestHandler.requestStats.getFetchDecodeStats().registerSuccessfulEvent(
-                    MathUtils.elapsedNanos(startDecodingEntriesNanos), TimeUnit.NANOSECONDS);
-            decodeResults.add(decodeResult);
+            String fullTopicName = KopTopic.toString(topicPartition, namespacePrefix);
+            SchemaManager schemaManager = requestHandler.getSchemaManager();
+            final CompletableFuture<DecodeResult> decodeResultFuture = requestHandler
+                    .getEntryFormatter().decode(entries, magic, fullTopicName, schemaManager);
+            decodeResultFuture.thenAccept((DecodeResult decodeResult) -> {
+                requestHandler.requestStats.getFetchDecodeStats().registerSuccessfulEvent(
+                        MathUtils.elapsedNanos(startDecodingEntriesNanos), TimeUnit.NANOSECONDS);
+                decodeResults.add(decodeResult);
 
-            final MemoryRecords kafkaRecords = decodeResult.getRecords();
-            // collect consumer metrics
-            decodeResult.updateConsumerStats(topicPartition,
-                    entries.size(),
-                    groupName,
-                    statsLogger);
-            List<FetchResponse.AbortedTransaction> abortedTransactions;
-            if (readCommitted) {
-                abortedTransactions = partitionLog.getAbortedIndexList(partitionData.fetchOffset);
-            } else {
-                abortedTransactions = null;
-            }
-            responseData.put(topicPartition, new PartitionData<>(
-                    Errors.NONE,
-                    highWatermark,
-                    lso,
-                    highWatermark, // TODO: should it be changed to the logStartOffset?
-                    abortedTransactions,
-                    kafkaRecords));
-            bytesReadable.getAndAdd(kafkaRecords.sizeInBytes());
-            tryComplete();
+                final MemoryRecords kafkaRecords = decodeResult.getRecords();
+                // collect consumer metrics
+                decodeResult.updateConsumerStats(topicPartition,
+                        entries.size(),
+                        groupName,
+                        statsLogger);
+                List<FetchResponse.AbortedTransaction> abortedTransactions;
+                if (readCommitted) {
+                    abortedTransactions = partitionLog.getAbortedIndexList(partitionData.fetchOffset);
+                } else {
+                    abortedTransactions = null;
+                }
+                responseData.put(topicPartition, new PartitionData<>(
+                        Errors.NONE,
+                        highWatermark,
+                        lso,
+                        highWatermark, // TODO: should it be changed to the logStartOffset?
+                        abortedTransactions,
+                        kafkaRecords));
+                bytesReadable.getAndAdd(kafkaRecords.sizeInBytes());
+                tryComplete();
+            });
         }, requestHandler.getDecodeExecutor());
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -510,6 +510,9 @@ public final class MessageFetchContext {
                         kafkaRecords));
                 bytesReadable.getAndAdd(kafkaRecords.sizeInBytes());
                 tryComplete();
+            }).exceptionally(err -> {
+                log.error("Internal error while decoding entries in topic {}", fullTopicName, err);
+                return null;
             });
         }, requestHandler.getDecodeExecutor());
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
@@ -41,6 +41,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import javax.naming.AuthenticationException;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.authentication.AuthenticationProvider;
@@ -59,6 +60,8 @@ public class SchemaRegistryManager {
     private final PulsarService pulsar;
     private final SchemaRegistryRequestAuthenticator schemaRegistryRequestAuthenticator;
     private final PulsarClient pulsarClient;
+    @Getter
+    private volatile SchemaStorageAccessor schemaStorage;
 
     public SchemaRegistryManager(KafkaServiceConfiguration kafkaConfig,
                                  PulsarService pulsar,
@@ -202,7 +205,7 @@ public class SchemaRegistryManager {
         }
         PulsarAdmin pulsarAdmin = pulsar.getAdminClient();
         SchemaRegistryHandler handler = new SchemaRegistryHandler();
-        SchemaStorageAccessor schemaStorage = new PulsarSchemaStorageAccessor((tenant) -> {
+        schemaStorage = new PulsarSchemaStorageAccessor((tenant) -> {
             try {
                 BrokerService brokerService = pulsar.getBrokerService();
                 final ClusterData clusterData = ClusterData.builder()

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/AbstractEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/AbstractEntryFormatter.java
@@ -23,6 +23,10 @@ import io.streamnative.pulsar.handlers.kop.utils.ByteBufUtils;
 import io.streamnative.pulsar.handlers.kop.utils.MessageMetadataUtils;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.util.MathUtils;
 import org.apache.bookkeeper.mledger.Entry;
@@ -41,9 +45,148 @@ public abstract class AbstractEntryFormatter implements EntryFormatter {
     public static final String IDENTITY_KEY = "entry.format";
     public static final String IDENTITY_VALUE = EntryFormatterFactory.EntryFormat.KAFKA.name().toLowerCase();
     private final Time time = Time.SYSTEM;
+    private final boolean applyAvroSchemaOnDecode;
+
+    public AbstractEntryFormatter(boolean applyAvroSchemaOnDecode) {
+        this.applyAvroSchemaOnDecode = applyAvroSchemaOnDecode;
+    }
 
     @Override
-    public DecodeResult decode(List<Entry> entries, byte magic) {
+    public final CompletableFuture<DecodeResult> decode(List<Entry> entries, byte magic,
+                                     String pulsarTopicName, SchemaManager schemaManager) {
+
+        if (!applyAvroSchemaOnDecode) {
+            return CompletableFuture.completedFuture(decodeSync(entries, magic, pulsarTopicName, schemaManager));
+        } else {
+            return decodeAsync(entries, magic, pulsarTopicName, schemaManager);
+        }
+    }
+
+    private CompletableFuture<DecodeResult> decodeAsync(List<Entry> entries, byte magic,
+                                                              String pulsarTopicName, SchemaManager schemaManager) {
+        AtomicInteger totalSize = new AtomicInteger();
+        AtomicInteger conversionCount = new AtomicInteger();
+        AtomicLong conversionTimeNanos = new AtomicLong();
+        // batched ByteBuf should be released after sending to client
+        ByteBuf batchedByteBuf = PulsarByteBufAllocator.DEFAULT.directBuffer();
+        CompletableFuture<DecodeResult> result = new CompletableFuture<>();
+
+        processEntry(entries, 0, magic, pulsarTopicName, schemaManager, totalSize, conversionCount, conversionTimeNanos,
+                    batchedByteBuf, result);
+
+        return result;
+    }
+
+    private void processEntry(List<Entry> entries, int index, byte magic, String pulsarTopicName,
+                              SchemaManager schemaManager, AtomicInteger totalSize,
+                              AtomicInteger conversionCount, AtomicLong conversionTimeNanos, ByteBuf batchedByteBuf,
+                              CompletableFuture<DecodeResult> result) {
+        if (index == entries.size()) {
+            result.complete(DecodeResult.get(
+                    MemoryRecords.readableRecords(ByteBufUtils.getNioBuffer(batchedByteBuf)),
+                    batchedByteBuf,
+                    conversionCount.get(),
+                    conversionTimeNanos.get()));
+            return;
+        }
+        Entry entry = entries.get(index);
+        try {
+            long startOffset = MessageMetadataUtils.peekBaseOffsetFromEntry(entry);
+            final ByteBuf byteBuf = entry.getDataBuffer();
+            final MessageMetadata metadata = MessageMetadataUtils.parseMessageMetadata(byteBuf);
+            if (isKafkaEntryFormat(metadata)) {
+                byte batchMagic = byteBuf.getByte(byteBuf.readerIndex() + MAGIC_OFFSET);
+                byteBuf.setLong(byteBuf.readerIndex() + OFFSET_OFFSET, startOffset);
+
+                // batch magic greater than the magic corresponding to the version requested by the client
+                // need down converted
+                if (batchMagic > magic) {
+                    long startConversionNanos = MathUtils.nowInNano();
+                    MemoryRecords memoryRecords = MemoryRecords.readableRecords(ByteBufUtils.getNioBuffer(byteBuf));
+                    // down converted, batch magic will be set to client magic
+                    ConvertedRecords<MemoryRecords> convertedRecords =
+                            memoryRecords.downConvert(magic, startOffset, time);
+                    conversionCount.addAndGet(convertedRecords.recordConversionStats().numRecordsConverted());
+                    conversionTimeNanos.addAndGet(MathUtils.elapsedNanos(startConversionNanos));
+
+                    final ByteBuf kafkaBuffer = Unpooled.wrappedBuffer(convertedRecords.records().buffer());
+                    totalSize.addAndGet(kafkaBuffer.readableBytes());
+                    batchedByteBuf.writeBytes(kafkaBuffer);
+                    kafkaBuffer.release();
+                    if (log.isTraceEnabled()) {
+                        log.trace("[{}:{}] MemoryRecords down converted, start offset {},"
+                                        + " entry magic: {}, client magic: {}",
+                                entry.getLedgerId(), entry.getEntryId(), startOffset, batchMagic, magic);
+                    }
+
+                } else {
+                    // not need down converted, batch magic retains the magic value written in production
+                    ByteBuf buf = byteBuf.slice(byteBuf.readerIndex(), byteBuf.readableBytes());
+                    totalSize.addAndGet(buf.readableBytes());
+                    batchedByteBuf.writeBytes(buf);
+                }
+                entry.release();
+                // next entry
+                processEntry(entries, index + 1, magic,
+                        pulsarTopicName, schemaManager, totalSize,
+                        conversionCount, conversionTimeNanos, batchedByteBuf,
+                        result);
+
+            } else {
+                ByteBufUtils.decodePulsarEntryToKafkaRecords(pulsarTopicName,
+                                metadata, byteBuf, startOffset,
+                                magic, schemaManager, applyAvroSchemaOnDecode)
+                        .thenAccept((DecodeResult decodeResult) -> {
+                    conversionCount.addAndGet(decodeResult.getConversionCount());
+                    conversionTimeNanos.addAndGet(decodeResult.getConversionTimeNanos());
+                    final ByteBuf kafkaBuffer = decodeResult.getOrCreateByteBuf();
+                    totalSize.addAndGet(kafkaBuffer.readableBytes());
+                    batchedByteBuf.writeBytes(kafkaBuffer);
+                    decodeResult.recycle();
+                    entry.release();
+
+                    // next entry
+                    processEntry(entries, index + 1, magic,
+                                    pulsarTopicName, schemaManager, totalSize,
+                                    conversionCount, conversionTimeNanos, batchedByteBuf,
+                                    result);
+                }).exceptionally(err -> {
+                    log.error("Error while decoding entry", err);
+                    entry.release();
+
+                    if ((err.getCause() instanceof MetadataCorruptedException)
+                        || (err.getCause() instanceof IOException)
+                            || (err.getCause() instanceof KafkaException)) {
+                        // next entry
+                        processEntry(entries, index + 1, magic,
+                                pulsarTopicName, schemaManager, totalSize,
+                                conversionCount, conversionTimeNanos, batchedByteBuf,
+                                result);
+                    } else {
+                        result.completeExceptionally(err);
+                    }
+                    return null;
+                });
+            }
+
+            // Almost all exceptions in Kafka inherit from KafkaException and will be captured
+            // and processed in KafkaApis. Here, whether it is down-conversion or the IOException
+            // in builder.appendWithOffset in decodePulsarEntryToKafkaRecords will be caught by Kafka
+            // and the KafkaException will be thrown. So we need to catch KafkaException here.
+        } catch (MetadataCorruptedException | IOException | KafkaException e) { // skip failed decode entry
+            entry.release();
+
+            // next entry
+            log.error("[{}:{}] Failed to decode entry. ", entry.getLedgerId(), entry.getEntryId(), e);
+            processEntry(entries, index + 1, magic,
+                    pulsarTopicName, schemaManager, totalSize,
+                    conversionCount, conversionTimeNanos, batchedByteBuf,
+                    result);
+        }
+    }
+
+    private DecodeResult decodeSync(List<Entry> entries, byte magic,
+                                         String pulsarTopicName, SchemaManager schemaManager) {
         int totalSize = 0;
         int conversionCount = 0;
         long conversionTimeNanos = 0L;
@@ -87,7 +230,9 @@ public abstract class AbstractEntryFormatter implements EntryFormatter {
                     }
                 } else {
                     final DecodeResult decodeResult =
-                            ByteBufUtils.decodePulsarEntryToKafkaRecords(metadata, byteBuf, startOffset, magic);
+                            ByteBufUtils.decodePulsarEntryToKafkaRecords(pulsarTopicName,
+                                    metadata, byteBuf, startOffset,
+                                    magic, schemaManager, false).get();
                     conversionCount += decodeResult.getConversionCount();
                     conversionTimeNanos += decodeResult.getConversionTimeNanos();
                     final ByteBuf kafkaBuffer = decodeResult.getOrCreateByteBuf();
@@ -102,6 +247,16 @@ public abstract class AbstractEntryFormatter implements EntryFormatter {
                 // and the KafkaException will be thrown. So we need to catch KafkaException here.
             } catch (MetadataCorruptedException | IOException | KafkaException e) { // skip failed decode entry
                 log.error("[{}:{}] Failed to decode entry. ", entry.getLedgerId(), entry.getEntryId(), e);
+            } catch (ExecutionException | InterruptedException e) {
+                batchedByteBuf.release();
+                if ((e.getCause() instanceof MetadataCorruptedException)
+                        || (e.getCause() instanceof IOException)
+                        || (e.getCause() instanceof KafkaException)) {
+                    log.error("[{}:{}] Failed to decode entry. ", entry.getLedgerId(), entry.getEntryId(), e);
+                } else {
+                    log.error("[{}:{}] Failed to process entry. ", entry.getLedgerId(), entry.getEntryId(), e);
+                    throw new RuntimeException(e);
+                }
             } finally {
                 entry.release();
             }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/AbstractEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/AbstractEntryFormatter.java
@@ -24,7 +24,6 @@ import io.streamnative.pulsar.handlers.kop.utils.MessageMetadataUtils;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
@@ -71,7 +70,7 @@ public abstract class AbstractEntryFormatter implements EntryFormatter {
      * @return
      */
     private CompletableFuture<DecodeResult> decodeAsync(List<Entry> entries, byte magic,
-                                                              String pulsarTopicName, SchemaManager schemaManager) {
+                                                        String pulsarTopicName, SchemaManager schemaManager) {
         AtomicInteger totalSize = new AtomicInteger();
         AtomicInteger conversionCount = new AtomicInteger();
         AtomicLong conversionTimeNanos = new AtomicLong();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/AbstractEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/AbstractEntryFormatter.java
@@ -121,6 +121,7 @@ public abstract class AbstractEntryFormatter implements EntryFormatter {
                     result);
             return;
         } catch (RuntimeException e) {
+            entry.release();
             log.error("[{}:{}] Fatal error while decoding entry. ", entry.getLedgerId(), entry.getEntryId(), e);
             result.completeExceptionally(e);
             return;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatter.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.kop.format;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MutableRecordBatch;
@@ -37,9 +38,12 @@ public interface EntryFormatter {
      *
      * @param entries the list of entries
      * @param magic the Kafka record batch's magic value
+     * @param pulsarTopicName the Topic Name in Pulsar
+     * @param schemaManager the SchemaManager
      * @return the DecodeResult contains the Kafka records
      */
-    DecodeResult decode(List<Entry> entries, byte magic);
+    CompletableFuture<DecodeResult> decode(List<Entry> entries, byte magic,
+                                           String pulsarTopicName, SchemaManager schemaManager);
 
     /**
      * Get the number of messages from MemoryRecords.

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterFactory.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterFactory.java
@@ -30,15 +30,16 @@ public class EntryFormatterFactory {
 
     public static EntryFormatter create(final KafkaServiceConfiguration kafkaConfig) {
         final String format = kafkaConfig.getEntryFormat();
+        final boolean applyAvroSchemaOnDecode = kafkaConfig.isApplyAvroSchemaOnDecode();
         try {
             EntryFormat entryFormat = Enum.valueOf(EntryFormat.class, format.toUpperCase());
             switch (entryFormat) {
                 case PULSAR:
-                    return new PulsarEntryFormatter();
+                    return new PulsarEntryFormatter(applyAvroSchemaOnDecode);
                 case KAFKA:
-                    return new KafkaV1EntryFormatter();
+                    return new KafkaV1EntryFormatter(applyAvroSchemaOnDecode);
                 case MIXED_KAFKA:
-                    return new KafkaMixedEntryFormatter();
+                    return new KafkaMixedEntryFormatter(applyAvroSchemaOnDecode);
                 default:
                     throw new Exception("No EntryFormatter for " + entryFormat);
             }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterFactory.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterFactory.java
@@ -30,7 +30,7 @@ public class EntryFormatterFactory {
 
     public static EntryFormatter create(final KafkaServiceConfiguration kafkaConfig) {
         final String format = kafkaConfig.getEntryFormat();
-        final boolean applyAvroSchemaOnDecode = kafkaConfig.isApplyAvroSchemaOnDecode();
+        final boolean applyAvroSchemaOnDecode = kafkaConfig.isKafkaApplyAvroSchemaOnDecode();
         try {
             EntryFormat entryFormat = Enum.valueOf(EntryFormat.class, format.toUpperCase());
             switch (entryFormat) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaMixedEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaMixedEntryFormatter.java
@@ -18,9 +18,7 @@ import io.netty.buffer.Unpooled;
 import io.streamnative.pulsar.handlers.kop.storage.PartitionLog;
 import io.streamnative.pulsar.handlers.kop.utils.KopLogValidator;
 import io.streamnative.pulsar.handlers.kop.utils.LongRef;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.bookkeeper.mledger.Entry;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.TimestampType;
@@ -34,6 +32,10 @@ import org.apache.pulsar.common.protocol.Commands;
  */
 @Slf4j
 public class KafkaMixedEntryFormatter extends AbstractEntryFormatter {
+
+    public KafkaMixedEntryFormatter(boolean applyAvroSchemaOnDecode) {
+        super(applyAvroSchemaOnDecode);
+    }
 
     @Override
     public EncodeResult encode(final EncodeRequest encodeRequest) {
@@ -70,11 +72,6 @@ public class KafkaMixedEntryFormatter extends AbstractEntryFormatter {
         validationAndOffsetAssignResult.recycle();
 
         return EncodeResult.get(validRecords, buf, numMessages, conversionCount, conversionTimeNanos);
-    }
-
-    @Override
-    public DecodeResult decode(List<Entry> entries, byte magic) {
-        return super.decode(entries, magic);
     }
 
     private static MessageMetadata getMessageMetadataWithNumberMessages(int numMessages) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaV1EntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaV1EntryFormatter.java
@@ -15,9 +15,7 @@ package io.streamnative.pulsar.handlers.kop.format;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.bookkeeper.mledger.Entry;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.protocol.Commands;
@@ -29,6 +27,10 @@ import org.apache.pulsar.common.protocol.Commands;
  */
 @Slf4j
 public class KafkaV1EntryFormatter extends AbstractEntryFormatter {
+
+    public KafkaV1EntryFormatter(boolean applyAvroSchemaOnDecode) {
+        super(applyAvroSchemaOnDecode);
+    }
 
     @Override
     public EncodeResult encode(final EncodeRequest encodeRequest) {
@@ -42,11 +44,6 @@ public class KafkaV1EntryFormatter extends AbstractEntryFormatter {
         recordsWrapper.release();
 
         return EncodeResult.get(records, buf, numMessages, 0, 0L);
-    }
-
-    @Override
-    public DecodeResult decode(List<Entry> entries, byte magic) {
-        return super.decode(entries, magic);
     }
 
     private static MessageMetadata getMessageMetadataWithNumberMessages(int numMessages) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarAdminSchemaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarAdminSchemaManager.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.format;
+
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.Schema;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorage;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.impl.schema.KeyValueSchemaInfo;
+import org.apache.pulsar.common.protocol.schema.BytesSchemaVersion;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+@AllArgsConstructor
+@Slf4j
+public class PulsarAdminSchemaManager implements SchemaManager{
+
+    private static final KeyValueSchemaIdsImpl NO_SCHEMA = new KeyValueSchemaIdsImpl(-1, -1);
+
+    private final String tenant;
+    private final PulsarAdmin pulsarAdmin;
+    private final SchemaStorageAccessor kafkaSchemaRegistry;
+    private final ConcurrentHashMap<String, KeyValueSchemaIds> cache = new ConcurrentHashMap<>();
+
+    @Override
+    public CompletableFuture<KeyValueSchemaIds> getSchemaIds(String topic, BytesSchemaVersion schemaVersion) {
+        if (schemaVersion == null) {
+            return CompletableFuture.completedFuture(NO_SCHEMA);
+        }
+        String subject = topic;
+        long version = ByteBuffer.wrap(schemaVersion.get()).getLong();
+        String cacheKey = subject + "__" + version;
+        KeyValueSchemaIds cachedValue  = cache.get(cacheKey);
+        if (cachedValue != null) {
+            return CompletableFuture.completedFuture(cachedValue);
+        }
+        SchemaStorage schemaStorageForTenant = kafkaSchemaRegistry.getSchemaStorageForTenant(tenant);
+        return pulsarAdmin.schemas().getSchemaInfoAsync(topic, version)
+                    .thenCompose((SchemaInfo schemaInfo) -> {
+            if (schemaInfo.getType() == SchemaType.KEY_VALUE) {
+                String schemaDefinition = schemaInfo.getSchemaDefinition();
+                log.info("lookup schema for {} - {}", subject, schemaDefinition);
+                KeyValue<SchemaInfo, SchemaInfo> kvSchemaInfo = KeyValueSchemaInfo.decodeKeyValueSchemaInfo(schemaInfo);
+                KeyValueEncodingType keyValueEncodingType = KeyValueSchemaInfo.decodeKeyValueEncodingType(schemaInfo);
+                if (keyValueEncodingType != KeyValueEncodingType.SEPARATED) {
+                    cache.put(cacheKey, NO_SCHEMA);
+                    return CompletableFuture.completedFuture(NO_SCHEMA);
+                }
+                SchemaInfo keySchema = kvSchemaInfo.getKey();
+                SchemaInfo valueSchema = kvSchemaInfo.getValue();
+                CompletableFuture<Integer> keySchemaIdFuture;
+                if (keySchema.getType() == SchemaType.AVRO) {
+                    keySchemaIdFuture = schemaStorageForTenant
+                            .createSchemaVersion(subject + "-key", Schema.TYPE_AVRO,
+                                    keySchema.getSchemaDefinition(), false)
+                            .thenApply(Schema::getId);
+                } else {
+                    keySchemaIdFuture = CompletableFuture.completedFuture(-1);
+                }
+                return keySchemaIdFuture.thenCompose((Integer keySchemaId) -> {
+                    log.info("keySchemaId {}", keySchemaId);
+                    CompletableFuture<Integer> valueSchemaIdFuture;
+                    if (valueSchema.getType() == SchemaType.AVRO) {
+                        valueSchemaIdFuture = schemaStorageForTenant
+                                .createSchemaVersion(subject, Schema.TYPE_AVRO,
+                                        valueSchema.getSchemaDefinition(), false)
+                                .thenApply(Schema::getId);
+                    } else {
+                        valueSchemaIdFuture = CompletableFuture.completedFuture(-1);
+                    }
+                    return valueSchemaIdFuture.thenApply((Integer valueSchemaId) -> {
+                        log.info("valueSchemaId {}", valueSchemaId);
+                        KeyValueSchemaIdsImpl res = new KeyValueSchemaIdsImpl(keySchemaId, valueSchemaId);
+                        cache.put(cacheKey, res);
+                        return res;
+                    });
+                });
+            } else if (schemaInfo.getType() == SchemaType.AVRO) {
+                String schemaDefinition = schemaInfo.getSchemaDefinition();
+                log.info("lookup schema for {} - {}", subject, schemaDefinition);
+                return schemaStorageForTenant
+                        .createSchemaVersion(subject, Schema.TYPE_AVRO, schemaDefinition, false)
+                        .thenApply((Schema kafkaSchema) -> {
+                            log.info("lookup schema for {} -> id {}", subject, kafkaSchema.getId());
+                            KeyValueSchemaIdsImpl res = new KeyValueSchemaIdsImpl(-1, kafkaSchema.getId());
+                            cache.put(cacheKey, res);
+                            return res;
+                        });
+            } else {
+                cache.put(cacheKey, NO_SCHEMA);
+                return CompletableFuture.completedFuture(NO_SCHEMA);
+            }
+        });
+
+    }
+
+    @AllArgsConstructor
+    private static final class KeyValueSchemaIdsImpl implements  KeyValueSchemaIds {
+        private final int keySchemaId;
+        private final int valueSchemaId;
+
+        @Override
+        public int getKeySchemaId() {
+            return keySchemaId;
+        }
+
+        @Override
+        public int getValueSchemaId() {
+            return valueSchemaId;
+        }
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.stream.StreamSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.util.MathUtils;
-import org.apache.bookkeeper.mledger.Entry;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.record.ControlRecordType;
 import org.apache.kafka.common.record.MemoryRecords;
@@ -43,6 +42,10 @@ public class PulsarEntryFormatter extends AbstractEntryFormatter {
     //// for Batch messages
     private static final int INITIAL_BATCH_BUFFER_SIZE = 1024;
     private static final int MAX_MESSAGE_BATCH_SIZE_BYTES = 128 * 1024;
+
+    public PulsarEntryFormatter(boolean applyAvroSchemaOnDecode) {
+        super(applyAvroSchemaOnDecode);
+    }
 
     @Override
     public EncodeResult encode(final EncodeRequest encodeRequest) {
@@ -111,11 +114,6 @@ public class PulsarEntryFormatter extends AbstractEntryFormatter {
 
         return EncodeResult.get(records, buf, numMessages, numMessagesInBatch,
                 MathUtils.elapsedNanos(startConversionNanos));
-    }
-
-    @Override
-    public DecodeResult decode(final List<Entry> entries, final byte magic) {
-        return super.decode(entries, magic);
     }
 
     // convert kafka Record to Pulsar Message.

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/SchemaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/SchemaManager.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.format;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.common.protocol.schema.BytesSchemaVersion;
+
+public interface SchemaManager {
+
+    interface KeyValueSchemaIds {
+        int getKeySchemaId();
+        int getValueSchemaId();
+    }
+
+    /**
+     * Returns the IDs in the Kafka Schema Registry for the given version of the Pulsar schema.
+     * @param topic
+     * @param schemaVersion
+     * @return
+     */
+    CompletableFuture<KeyValueSchemaIds> getSchemaIds(String topic, BytesSchemaVersion schemaVersion);
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
@@ -25,7 +25,6 @@ import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import javax.annotation.processing.Completion;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.util.MathUtils;
@@ -151,8 +150,8 @@ public class ByteBufUtils {
         if (decodeResultForMarker != null) {
             return CompletableFuture.completedFuture(decodeResultForMarker);
         }
-        CompletableFuture<SchemaManager.KeyValueSchemaIds> schemaIdsFuture
-                = CompletableFuture.completedFuture(null);
+        CompletableFuture<SchemaManager.KeyValueSchemaIds> schemaIdsFuture =
+                CompletableFuture.completedFuture(null);
         if (metadata.hasSchemaVersion()) {
             BytesSchemaVersion version = BytesSchemaVersion.of(metadata.getSchemaVersion());
             if (version != null) {
@@ -164,13 +163,14 @@ public class ByteBufUtils {
                     return encodeKafkaResponse(metadata, payload, baseOffset, magic, schemaIds);
                 } catch (IOException err) {
                             throw new CompletionException(err);
-                }}
-        );
+                }
+        });
     }
 
     @NonNull
-    private static DecodeResult encodeKafkaResponse(MessageMetadata metadata, ByteBuf payload, long baseOffset, byte magic,
-                                                SchemaManager.KeyValueSchemaIds schemaIds) throws IOException {
+    private static DecodeResult encodeKafkaResponse(MessageMetadata metadata, ByteBuf payload, long baseOffset,
+                                                    byte magic, SchemaManager.KeyValueSchemaIds schemaIds)
+            throws IOException {
 
         int keySchemaId = schemaIds == null ? -1 : schemaIds.getKeySchemaId();
         int valueSchemaId = schemaIds == null ? -1 : schemaIds.getValueSchemaId();

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/NoHeaderKafkaEntryFormatter.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/NoHeaderKafkaEntryFormatter.java
@@ -15,6 +15,7 @@ package io.streamnative.pulsar.handlers.kop.format;
 
 import io.netty.buffer.Unpooled;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.kafka.common.record.MemoryRecords;
 
@@ -33,7 +34,8 @@ public class NoHeaderKafkaEntryFormatter implements EntryFormatter {
     }
 
     @Override
-    public DecodeResult decode(List<Entry> entries, byte magic) {
+    public CompletableFuture<DecodeResult> decode(List<Entry> entries, byte magic,
+                                                  String topic, SchemaManager schemaManager) {
         // Do nothing
         return null;
     }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/NoHeaderKafkaEntryFormatter.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/NoHeaderKafkaEntryFormatter.java
@@ -37,6 +37,6 @@ public class NoHeaderKafkaEntryFormatter implements EntryFormatter {
     public CompletableFuture<DecodeResult> decode(List<Entry> entries, byte magic,
                                                   String topic, SchemaManager schemaManager) {
         // Do nothing
-        return null;
+        return CompletableFuture.completedFuture(null);
     }
 }

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/SchemaStorageAccessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/SchemaStorageAccessor.java
@@ -13,14 +13,12 @@
  */
 package io.streamnative.pulsar.handlers.kop.schemaregistry.model;
 
-import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.SchemaStorageException;
-
 /**
  * Accesses the SchemaStorage instance for a given tenant.
  */
 public interface SchemaStorageAccessor extends AutoCloseable {
 
-    SchemaStorage getSchemaStorageForTenant(String tenant) throws SchemaStorageException;
+    SchemaStorage getSchemaStorageForTenant(String tenant);
 
     @Override
     void close();

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageAccessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageAccessor.java
@@ -29,14 +29,15 @@ public class PulsarSchemaStorageAccessor implements SchemaStorageAccessor {
     private final String topicName;
 
     @Override
-    public PulsarSchemaStorage getSchemaStorageForTenant(String tenant) throws SchemaStorageException {
+    public PulsarSchemaStorage getSchemaStorageForTenant(String tenant) {
         if (tenant == null) {
-            throw new SchemaStorageException("Invalid Tenant null");
+            throw new IllegalArgumentException("Invalid Tenant null");
         }
         return tenants.computeIfAbsent(tenant, t -> {
             String fullTopicName = "persistent://" + t + "/" + namespaceName + "/" + topicName;
             log.info("Building Pulsar Client for Schema Registry for Tenant {}, data topic {}", tenant, fullTopicName);
             PulsarClient pulsarClient = authenticatedClientBuilder.apply(t);
+            log.info("Done {} {}", tenant, fullTopicName);
             return new PulsarSchemaStorage(t, pulsarClient, fullTopicName);
         });
     }

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageAccessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageAccessor.java
@@ -37,7 +37,6 @@ public class PulsarSchemaStorageAccessor implements SchemaStorageAccessor {
             String fullTopicName = "persistent://" + t + "/" + namespaceName + "/" + topicName;
             log.info("Building Pulsar Client for Schema Registry for Tenant {}, data topic {}", tenant, fullTopicName);
             PulsarClient pulsarClient = authenticatedClientBuilder.apply(t);
-            log.info("Done {} {}", tenant, fullTopicName);
             return new PulsarSchemaStorage(t, pulsarClient, fullTopicName);
         });
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryProxyTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryProxyTest.java
@@ -16,12 +16,27 @@ package io.streamnative.pulsar.handlers.kop;
 import lombok.extern.slf4j.Slf4j;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Factory;
 
 /**
  * Test for KoP with Confluent Schema Registry.
  */
 @Slf4j
 public class SchemaRegistryProxyTest extends SchemaRegistryTest {
+
+    @Factory
+    public static Object[] instances() {
+        return new Object[] {
+                new SchemaRegistryProxyTest("pulsar", false),
+                new SchemaRegistryProxyTest("pulsar", true),
+                new SchemaRegistryProxyTest("kafka", false),
+                new SchemaRegistryProxyTest("kafka", true)
+        };
+    }
+
+    public SchemaRegistryProxyTest(String entryFormat, boolean applyAvroSchemaOnDecode) {
+        super(entryFormat, applyAvroSchemaOnDecode);
+    }
 
     @BeforeClass
     @Override

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryProxyTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryProxyTest.java
@@ -50,7 +50,6 @@ public class SchemaRegistryProxyTest extends SchemaRegistryTest {
     @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
-        log.info("STOPPING");
         stopProxy();
         super.cleanup();
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryProxyTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryProxyTest.java
@@ -14,14 +14,12 @@
 package io.streamnative.pulsar.handlers.kop;
 
 import lombok.extern.slf4j.Slf4j;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Factory;
 
 /**
- * Test for KoP with Confluent Schema Registry.
+ * Test for KoP with Confluent Schema Registry served by the Proxy.
  */
 @Slf4j
 public class SchemaRegistryProxyTest extends SchemaRegistryTest {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryProxyTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryProxyTest.java
@@ -15,7 +15,9 @@ package io.streamnative.pulsar.handlers.kop;
 
 import lombok.extern.slf4j.Slf4j;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Factory;
 
 /**
@@ -38,7 +40,7 @@ public class SchemaRegistryProxyTest extends SchemaRegistryTest {
         super(entryFormat, applyAvroSchemaOnDecode);
     }
 
-    @BeforeClass
+    @BeforeMethod
     @Override
     protected void setup() throws Exception {
         super.setup();
@@ -47,9 +49,10 @@ public class SchemaRegistryProxyTest extends SchemaRegistryTest {
         bootstrapServers = "localhost:" + getClientPort();
     }
 
-    @AfterClass
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
+        log.info("STOPPING");
         stopProxy();
         super.cleanup();
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryTest.java
@@ -161,7 +161,6 @@ public class SchemaRegistryTest extends KopProtocolHandlerTestBase {
                 i++;
             }
         }
-        consumer.close();
     }
 
     @Data
@@ -225,7 +224,6 @@ public class SchemaRegistryTest extends KopProtocolHandlerTestBase {
             }
         }
         assertEquals(numMessages, i);
-        consumer.close();
     }
 
     @Test(timeOut = 120000, dataProvider = "enableBatchingProvider")
@@ -275,6 +273,5 @@ public class SchemaRegistryTest extends KopProtocolHandlerTestBase {
             }
         }
         assertEquals(numMessages, i);
-        consumer.close();
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryTest.java
@@ -47,7 +47,9 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
@@ -77,7 +79,7 @@ public class SchemaRegistryTest extends KopProtocolHandlerTestBase {
         this.applyAvroSchemaOnDecode = applyAvroSchemaOnDecode;
     }
 
-    @BeforeMethod
+    @BeforeClass
     @Override
     protected void setup() throws Exception {
         super.enableSchemaRegistry = true;
@@ -86,7 +88,7 @@ public class SchemaRegistryTest extends KopProtocolHandlerTestBase {
         bootstrapServers = "localhost:" + getKafkaBrokerPort();
     }
 
-    @AfterMethod(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         this.internalCleanup();
@@ -233,7 +235,7 @@ public class SchemaRegistryTest extends KopProtocolHandlerTestBase {
         if (!applyAvroSchemaOnDecode) {
             return;
         }
-        String topic = "SchemaRegistryTest-testProduceAvroPulsarAndConsume_"
+        String topic = "SchemaRegistryTest-testProduceAvroKeyValuePulsarAndConsume_"
                 + entryFormat + "_" + applyAvroSchemaOnDecode + "_" + enableBatching;
         @Cleanup
         Producer<KeyValue<PojoKey, Pojo>> pojoProducer = pulsarClient.newProducer(

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryTest.java
@@ -48,9 +48,7 @@ import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
@@ -83,7 +81,7 @@ public class SchemaRegistryTest extends KopProtocolHandlerTestBase {
     @Override
     protected void setup() throws Exception {
         super.enableSchemaRegistry = true;
-        this.conf.setApplyAvroSchemaOnDecode(applyAvroSchemaOnDecode);
+        this.conf.setKafkaApplyAvroSchemaOnDecode(applyAvroSchemaOnDecode);
         this.internalSetup();
         bootstrapServers = "localhost:" + getKafkaBrokerPort();
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryTest.java
@@ -20,10 +20,15 @@ import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import lombok.AllArgsConstructor;
 import lombok.Cleanup;
+import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -37,8 +42,15 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
 /**
@@ -48,15 +60,28 @@ import org.testng.annotations.Test;
 public class SchemaRegistryTest extends KopProtocolHandlerTestBase {
 
     protected String bootstrapServers;
+    protected boolean applyAvroSchemaOnDecode;
 
-    public SchemaRegistryTest() {
-        super("pulsar");
+    @Factory
+    public static Object[] instances() {
+        return new Object[] {
+                new SchemaRegistryTest("pulsar", false),
+                new SchemaRegistryTest("pulsar", true),
+                new SchemaRegistryTest("kafka", false),
+                new SchemaRegistryTest("kafka", true)
+        };
+    }
+
+    public SchemaRegistryTest(String entryFormat, boolean applyAvroSchemaOnDecode) {
+        super(entryFormat);
+        this.applyAvroSchemaOnDecode = applyAvroSchemaOnDecode;
     }
 
     @BeforeMethod
     @Override
     protected void setup() throws Exception {
         super.enableSchemaRegistry = true;
+        this.conf.setApplyAvroSchemaOnDecode(applyAvroSchemaOnDecode);
         this.internalSetup();
         bootstrapServers = "localhost:" + getKafkaBrokerPort();
     }
@@ -86,20 +111,24 @@ public class SchemaRegistryTest extends KopProtocolHandlerTestBase {
         return new KafkaProducer<>(props);
     }
 
-    private KafkaConsumer<Integer, Object> createAvroConsumer() {
+    private <K, V> KafkaConsumer<K, V> createAvroConsumer() {
+        return createAvroConsumer(IntegerDeserializer.class, KafkaAvroDeserializer.class);
+    }
+
+    private <K, V> KafkaConsumer<K, V> createAvroConsumer(Class deserializer, Class serializer) {
         Properties props = new Properties();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ConsumerConfig.GROUP_ID_CONFIG, "avroGroup");
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class);
-        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, deserializer);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, serializer);
         props.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, restConnect);
         return new KafkaConsumer<>(props);
     }
 
     @Test(timeOut = 120000)
     public void testAvroProduceAndConsume() throws Throwable {
-        String topic = "SchemaRegistryTest-testAvroProduceAndConsume";
+        String topic = "SchemaRegistryTest-testAvroProduceAndConsume_" + entryFormat + "_" + applyAvroSchemaOnDecode;
         IndexedRecord avroRecord = createAvroRecord();
         Object[] objects = new Object[]{avroRecord, true, 130, 345L, 1.23f, 2.34d, "abc", "def".getBytes()};
         @Cleanup
@@ -132,6 +161,120 @@ public class SchemaRegistryTest extends KopProtocolHandlerTestBase {
                 i++;
             }
         }
+        consumer.close();
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class Pojo {
+        private String name;
+        private int age;
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class PojoKey {
+        private long pk;
+    }
+
+    @DataProvider(name = "enableBatchingProvider")
+    protected static Object[][] batchProvider() {
+        // isBatch
+        return new Object[][]{
+                {true},
+                {false}
+        };
+    }
+
+    @Test(timeOut = 120000, dataProvider = "enableBatchingProvider")
+    public void testProduceAvroPulsarAndConsume(boolean enableBatching) throws Throwable {
+        if (!applyAvroSchemaOnDecode) {
+            return;
+        }
+        String topic = "SchemaRegistryTest-testProduceAvroPulsarAndConsume_"
+                + entryFormat + "_" + applyAvroSchemaOnDecode + "_" + enableBatching;
+        @Cleanup
+        Producer<Pojo> pojoProducer = pulsarClient.newProducer(org.apache.pulsar.client.api.Schema.AVRO(Pojo.class))
+                .topic(topic)
+                .enableBatching(true)
+                .batchingMaxMessages(10)
+                .blockIfQueueFull(true)
+                .batchingMaxPublishDelay(1, TimeUnit.SECONDS)
+                .create();
+
+        final int numMessages = 100;
+        List<CompletableFuture<?>> handles = new ArrayList<>();
+        for (int i = 0; i < numMessages; i++) {
+            handles.add(pojoProducer.newMessage().value(new Pojo("foo", 1)).key("test").sendAsync());
+        }
+        FutureUtil.waitForAll(handles).get();
+
+        log.info("finished sending");
+
+        @Cleanup
+        KafkaConsumer<String, GenericRecord> consumer = createAvroConsumer(StringDeserializer.class,
+                KafkaAvroDeserializer.class);
+        consumer.subscribe(Collections.singleton(topic));
+        int i = 0;
+        while (i < numMessages){
+            for (ConsumerRecord<String, GenericRecord> record : consumer.poll(Duration.ofSeconds(3))) {
+               assertEquals(record.key(), "test");
+               assertEquals(record.value().get("name").toString(), "foo");
+               assertEquals(record.value().get("age"), 1);
+                i++;
+            }
+        }
+        assertEquals(numMessages, i);
+        consumer.close();
+    }
+
+    @Test(timeOut = 120000, dataProvider = "enableBatchingProvider")
+    public void testProduceAvroKeyValuePulsarAndConsume(boolean enableBatching) throws Throwable {
+        if (!applyAvroSchemaOnDecode) {
+            return;
+        }
+        String topic = "SchemaRegistryTest-testProduceAvroPulsarAndConsume_"
+                + entryFormat + "_" + applyAvroSchemaOnDecode + "_" + enableBatching;
+        @Cleanup
+        Producer<KeyValue<PojoKey, Pojo>> pojoProducer = pulsarClient.newProducer(
+                org.apache.pulsar.client.api.Schema.KeyValue(
+                  org.apache.pulsar.client.api.Schema.AVRO(PojoKey.class),
+                  org.apache.pulsar.client.api.Schema.AVRO(Pojo.class),
+                        KeyValueEncodingType.SEPARATED)
+                )
+                .topic(topic)
+                .enableBatching(enableBatching)
+                .batchingMaxMessages(10)
+                .blockIfQueueFull(true)
+                .batchingMaxPublishDelay(1, TimeUnit.SECONDS)
+                .create();
+
+        final int numMessages = 100;
+        List<CompletableFuture<?>> handles = new ArrayList<>();
+        for (int i = 0; i < numMessages; i++) {
+            handles.add(pojoProducer.newMessage().value(
+                            new KeyValue<>(new PojoKey(12314L),
+                                    new Pojo("foo", 1)))
+                    .sendAsync());
+        }
+        FutureUtil.waitForAll(handles).get();
+
+        log.info("finished sending");
+
+        @Cleanup
+        KafkaConsumer<GenericRecord, GenericRecord> consumer = createAvroConsumer(KafkaAvroDeserializer.class,
+                KafkaAvroDeserializer.class);
+        consumer.subscribe(Collections.singleton(topic));
+        int i = 0;
+        while (i < numMessages){
+            for (ConsumerRecord<GenericRecord, GenericRecord> record : consumer.poll(Duration.ofSeconds(3))) {
+                assertEquals(record.key().get("pk"), 12314L);
+                assertEquals(record.value().get("name").toString(), "foo");
+                assertEquals(record.value().get("age"), 1);
+                i++;
+            }
+        }
+        assertEquals(numMessages, i);
         consumer.close();
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageTest.java
@@ -37,7 +37,7 @@ public class PulsarSchemaStorageTest extends KopProtocolHandlerTestBase {
         admin.topics().createNonPartitionedTopic("persistent://public/default/__schemaregistry");
         SchemaStorageTestsBase tester = new SchemaStorageTestsBase(new SchemaStorageAccessor() {
             @Override
-            public SchemaStorage getSchemaStorageForTenant(String tenant) throws SchemaStorageException {
+            public SchemaStorage getSchemaStorageForTenant(String tenant) {
                 return new PulsarSchemaStorage(tenant, pulsarClient,
                         "persistent://public/default/__schemaregistry");
             }


### PR DESCRIPTION
Motivation:
When you produce messages using Pulsar and you produce AVRO (or KeyValue<AVRO,AVRO> messages), for instance when using Pulsar Debezium CDC Sources, it is currently not possible to consume easily such messages using Kafka
Kafka users are used to use Confluent KafkaAvroDeserializer to consume AVRO data, and that deserialiser works with a special encoding of the payload:
- 1 byte magic: 0
- 4 bytes: id of the Schema in the SchemaRegistry
- AVRO payload
This happens both for the key and for the value. 


Modifications:
With this patch when you consume data from a Pulsar topic that uses AVRO or KeyValue<AVRO, AVRO> schemas, then we encode the final Kafka payload using KafkaAvroDeserializer format.

This is not trivial as we have to:
- lookup the schema in the Pulsar schema registry
- lookup (and possibly store) the Schema in the Kafka Schema Registry
- re-encode the key/value before sending it to the Kafka client

the lookup operations are async, so we have to change a little bit the "decode" part in order to make it fully async.


With this patch when you configure `kafkaApplyAvroSchemaOnDecode=false `(default) the execution path is basically the same as before, so no performance impact should be visible.

When you configure `kafkaApplyAvroSchemaOnDecode=true` the execution path is different, and we have to create a few more objects on the heap and we have to perform more method calls, because we are not processing the entries in a loop but inside a chain of CompletableFuture callbacks