### PR TITLE
[improvement] Save resources on the BK threads by not accessing the metrics context

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -31,11 +31,13 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.util.MathUtils;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
+import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -193,22 +195,21 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
         ByteBuf buffer = (ByteBuf) msg;
         requestStats.getNetworkTotalBytesIn().add(buffer.readableBytes());
 
+        OpStatsLogger requestParseLatencyStats = requestStats.getRequestParseLatencyStats();
         // Update parse request latency metrics
         final BiConsumer<Long, Throwable> registerRequestParseLatency = (timeBeforeParse, throwable) -> {
-            requestStats.getRequestParseLatencyStats().registerSuccessfulEvent(
+            requestParseLatencyStats.registerSuccessfulEvent(
                     MathUtils.elapsedNanos(timeBeforeParse), TimeUnit.NANOSECONDS);
-        };
-
-        // Update handle request latency metrics
-        final BiConsumer<ApiKeys, Long> registerRequestLatency = (apiKey, startProcessTime) -> {
-            requestStats.getRequestStatsLogger(apiKey, KopServerStats.REQUEST_LATENCY)
-                    .registerSuccessfulEvent(MathUtils.elapsedNanos(startProcessTime), TimeUnit.NANOSECONDS);
         };
 
         // If kop is enabled for authentication and the client
         // has not completed the handshake authentication,
         // execute channelPrepare to complete authentication
         if (isActive.get() && !channelReady()) {
+            final BiConsumer<ApiKeys, Long> registerRequestLatency = (apiKey, startProcessTime) -> {
+                requestStats.getRequestStatsLogger(apiKey, KopServerStats.REQUEST_LATENCY)
+                        .registerSuccessfulEvent(MathUtils.elapsedNanos(startProcessTime), TimeUnit.NANOSECONDS);
+            };
             try {
                 channelPrepare(ctx, buffer, registerRequestParseLatency, registerRequestLatency);
                 return;
@@ -232,6 +233,13 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
         // potentially blocking until there is room in the queue for the request.
         registerRequestParseLatency.accept(timeBeforeParse, null);
 
+        OpStatsLogger requestStatsLogger = requestStats.getRequestStatsLogger(kafkaHeaderAndRequest.header.apiKey(),
+                KopServerStats.REQUEST_LATENCY);
+        // Update handle request latency metrics
+        final Consumer<Long> registerRequestLatency = (startProcessTime) -> {
+            requestStatsLogger
+                    .registerSuccessfulEvent(MathUtils.elapsedNanos(startProcessTime), TimeUnit.NANOSECONDS);
+        };
         try {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Received kafka cmd {}, the request content is: {}",
@@ -252,14 +260,13 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
                     return;
                 }
 
-                registerRequestLatency.accept(kafkaHeaderAndRequest.getHeader().apiKey(),
-                        startProcessRequestTimestamp);
-
                 if (sendResponseScheduler != null) {
                     sendResponseScheduler.executeOrdered(channel.remoteAddress().hashCode(), () -> {
+                        registerRequestLatency.accept(startProcessRequestTimestamp);
                         writeAndFlushResponseToClient(channel);
                     });
                 } else {
+                    registerRequestLatency.accept(startProcessRequestTimestamp);
                     writeAndFlushResponseToClient(channel);
                 }
             });


### PR DESCRIPTION


### Motivation
I am investigating some performance tests (mostly about end-to-end latency) and I have found this weird behaviour.

Bad behaviour:
```

"BookKeeperClientWorker-OrderedExecutor-3-0" #46 prio=5 os_prio=0 cpu=158666.94ms elapsed=4568.73s tid=0x00007f3d6ddefdd0 nid=0x5bbb runnable  [0x00007f3c592f0000]
   java.lang.Thread.State: RUNNABLE
	at java.util.regex.Pattern$BmpCharPredicate.lambda$union$2(java.base@17.0.5/Pattern.java:5626)
	at java.util.regex.Pattern$BmpCharPredicate$$Lambda$22/0x80000002b.is(java.base@17.0.5/Unknown Source)
	at java.util.regex.Pattern$BmpCharPredicate.lambda$union$2(java.base@17.0.5/Pattern.java:5626)
	at java.util.regex.Pattern$BmpCharPredicate$$Lambda$22/0x80000002b.is(java.base@17.0.5/Unknown Source)
	at java.util.regex.Pattern$BmpCharPredicate.lambda$union$2(java.base@17.0.5/Pattern.java:5626)
	at java.util.regex.Pattern$BmpCharPredicate$$Lambda$22/0x80000002b.is(java.base@17.0.5/Unknown Source)
	at java.util.regex.Pattern$CharPredicate.lambda$negate$3(java.base@17.0.5/Pattern.java:5613)
	at java.util.regex.Pattern$CharPredicate$$Lambda$23/0x80000002d.is(java.base@17.0.5/Unknown Source)
	at java.util.regex.Pattern$CharProperty.match(java.base@17.0.5/Pattern.java:3930)
	at java.util.regex.Pattern$StartS.match(java.base@17.0.5/Pattern.java:3641)
	at java.util.regex.Matcher.search(java.base@17.0.5/Matcher.java:1728)
	at java.util.regex.Matcher.find(java.base@17.0.5/Matcher.java:745)
	at java.util.regex.Matcher.replaceAll(java.base@17.0.5/Matcher.java:1177)
	at io.prometheus.client.Collector.sanitizeMetricName(Collector.java:195)
	at io.streamnative.pulsar.handlers.kop.stats.PrometheusStatsLogger.completeName(PrometheusStatsLogger.java:81)
	at io.streamnative.pulsar.handlers.kop.stats.PrometheusStatsLogger.scopeContext(PrometheusStatsLogger.java:77)
	at io.streamnative.pulsar.handlers.kop.stats.PrometheusStatsLogger.getOpStatsLogger(PrometheusStatsLogger.java:41)
	at io.streamnative.pulsar.handlers.kop.RequestStats.getRequestStatsLogger(RequestStats.java:234)
	at io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder.lambda$channelRead$1(KafkaCommandDecoder.java:207)
	at io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder$$Lambda$1966/0x00000008013b0bb0.accept(Unknown Source)
	at io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder.lambda$channelRead$3(KafkaCommandDecoder.java:258)
	at io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder$$Lambda$2047/0x000000080131b278.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniWhenComplete(java.base@17.0.5/CompletableFuture.java:863)
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(java.base@17.0.5/CompletableFuture.java:841)
	at java.util.concurrent.CompletableFuture.postComplete(java.base@17.0.5/CompletableFuture.java:510)
	at java.util.concurrent.CompletableFuture.complete(java.base@17.0.5/CompletableFuture.java:2147)
	at io.streamnative.pulsar.handlers.kop.KafkaRequestHandler.lambda$handleProduceRequest$37(KafkaRequestHandler.java:883)
	at io.streamnative.pulsar.handlers.kop.KafkaRequestHandler$$Lambda$2427/0x00000008014e46c8.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniWhenComplete(java.base@17.0.5/CompletableFuture.java:863)
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(java.base@17.0.5/CompletableFuture.java:841)
	at java.util.concurrent.CompletableFuture.postComplete(java.base@17.0.5/CompletableFuture.java:510)
	at java.util.concurrent.CompletableFuture.complete(java.base@17.0.5/CompletableFuture.java:2147)
	at io.streamnative.pulsar.handlers.kop.storage.ReplicaManager$PendingProduceCallback.run(ReplicaManager.java:97)
	at io.streamnative.pulsar.handlers.kop.storage.ReplicaManager.lambda$appendRecords$0(ReplicaManager.java:131)
	at io.streamnative.pulsar.handlers.kop.storage.ReplicaManager$$Lambda$2329/0x00000008014c5af8.accept(Unknown Source)
	at io.streamnative.pulsar.handlers.kop.storage.ReplicaManager.lambda$appendRecords$1(ReplicaManager.java:144)
	at io.streamnative.pulsar.handlers.kop.storage.ReplicaManager$$Lambda$2416/0x00000008014dab20.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture$UniAccept.tryFire(java.base@17.0.5/CompletableFuture.java:718)
	at java.util.concurrent.CompletableFuture.postComplete(java.base@17.0.5/CompletableFuture.java:510)
	at java.util.concurrent.CompletableFuture.complete(java.base@17.0.5/CompletableFuture.java:2147)
	at io.streamnative.pulsar.handlers.kop.storage.PartitionLog.lambda$publishMessages$14(PartitionLog.java:777)
	at io.streamnative.pulsar.handlers.kop.storage.PartitionLog$$Lambda$2403/0x00000008014d9490.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniWhenComplete(java.base@17.0.5/CompletableFuture.java:863)
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(java.base@17.0.5/CompletableFuture.java:841)
	at java.util.concurrent.CompletableFuture.postComplete(java.base@17.0.5/CompletableFuture.java:510)
	at java.util.concurrent.CompletableFuture.complete(java.base@17.0.5/CompletableFuture.java:2147)
	at io.streamnative.pulsar.handlers.kop.MessagePublishContext.completed(MessagePublishContext.java:126)
	at org.apache.pulsar.broker.service.persistent.PersistentTopic.addComplete(PersistentTopic.java:522)
	at org.apache.bookkeeper.mledger.impl.OpAddEntry.safeRun(OpAddEntry.java:232)
	at org.apache.bookkeeper.common.util.SafeRunnable.run(SafeRunnable.java:36)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@17.0.5/ThreadPoolExecutor.java:1136)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@17.0.5/ThreadPoolExecutor.java:635)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(java.base@17.0.5/Thread.java:833)
```


Sample of better behaviour (execute stuff on the "send-response" threadpool:
```
"send-response-OrderedScheduler-3-0" #41 prio=5 os_prio=0 cpu=148275.60ms elapsed=4568.79s tid=0x00007f3d6dd878f0 nid=0x5bb6 runnable  [0x00007f3ca0d33000]
   java.lang.Thread.State: RUNNABLE
	at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:758)
	at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:808)
	at io.netty.channel.DefaultChannelPipeline.writeAndFlush(DefaultChannelPipeline.java:1025)
	at io.netty.channel.AbstractChannel.writeAndFlush(AbstractChannel.java:306)
	at io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder.lambda$writeAndFlushResponseToClient$6(KafkaCommandDecoder.java:450)
	at io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder$$Lambda$2053/0x0000000801312a50.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniAcceptNow(java.base@17.0.5/CompletableFuture.java:757)
	at java.util.concurrent.CompletableFuture.uniAcceptStage(java.base@17.0.5/CompletableFuture.java:735)
	at java.util.concurrent.CompletableFuture.thenAccept(java.base@17.0.5/CompletableFuture.java:2182)
	at io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder.writeAndFlushResponseToClient(KafkaCommandDecoder.java:433)
	at io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder.lambda$channelRead$2(KafkaCommandDecoder.java:263)
	at io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder$$Lambda$2051/0x0000000801313490.safeRun(Unknown Source)
	at org.apache.bookkeeper.common.util.SafeRunnable.run(SafeRunnable.java:36)
	at java.util.concurrent.Executors$RunnableAdapter.call(java.base@17.0.5/Executors.java:539)
	at java.util.concurrent.FutureTask.run(java.base@17.0.5/FutureTask.java:264)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(java.base@17.0.5/ScheduledThreadPoolExecutor.java:304)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@17.0.5/ThreadPoolExecutor.java:1136)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@17.0.5/ThreadPoolExecutor.java:635)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(java.base@17.0.5/Thread.java:833)
```

### Modifications
Calculate the metric name in the client IO thread (that is only used by the Protocol Handler) and not in the BK thread ( that is shared with many other components in the Pulsar broker)