### PR TITLE
[transactions] Purge old Aborted transactions DRAFT + Other improvements on the Producer State recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,8 @@ docker.debug-info
 **/website/i18n/*
 **/website/translated_docs*
 
+
+# docker test env
+docker/testImage/*.tar.gz
+docker/testImage/*.nar
+

--- a/docker/testImage/Dockerfile
+++ b/docker/testImage/Dockerfile
@@ -1,0 +1,7 @@
+FROM us-central1-docker.pkg.dev/datastax-gcp-pulsar/pulsar/lunastreaming-all:latest-210
+USER root
+RUN apt-get update && apt-get -y install openjdk-11-dbg
+RUN rm /pulsar/protocols/*.nar /pulsar/proxyextensions/*.nar
+ADD async-profiler-2.9-linux-x64.tar.gz /pulsar/
+ADD *proxy*nar /pulsar/proxyextensions/
+ADD *handler*nar /pulsar/protocols/

--- a/docker/testImage/build.sh
+++ b/docker/testImage/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+IMAGETAG=$1
+
+set -x -e
+
+if [[ ! -f "async-profiler-2.9-linux-x64.tar.gz" ]] ; then
+    curl -L -O https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.9/async-profiler-2.9-linux-x64.tar.gz
+fi
+
+mvn clean install -DskipTests -pl kafka-impl,proxy -f ../../pom.xml
+rm -f *.nar
+cp ../../proxy/target/*.nar .
+cp ../../kafka-impl/target/*.nar .
+docker build . -t $IMAGETAG
+docker push $IMAGETAG

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -157,7 +157,8 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
         return ListOffsetRequestV0.parse(nio, apiVersion);
     }
 
-    protected static ByteBuf responseToByteBuf(AbstractResponse response, KafkaHeaderAndRequest request) {
+    protected static ByteBuf responseToByteBuf(AbstractResponse response, KafkaHeaderAndRequest request,
+            boolean release) {
         try (KafkaHeaderAndResponse kafkaHeaderAndResponse =
                  KafkaHeaderAndResponse.responseForRequest(request, response)) {
             // Lowering Client API_VERSION request to the oldest API_VERSION KoP supports, this is to make \
@@ -175,8 +176,10 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
                 kafkaHeaderAndResponse.getResponse()
             );
         } finally {
-            // the request is not needed any more.
-            request.close();
+            if (release) {
+                // the request is not needed any more.
+                request.close();
+            }
         }
     }
 
@@ -413,7 +416,7 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
             if (responseFuture.isCompletedExceptionally()) {
                 responseFuture.exceptionally(e -> {
                     log.error("[{}] request {} completed exceptionally", channel, request.getHeader(), e);
-                    sendErrorResponse(request, channel, e);
+                    sendErrorResponse(request, channel, e, true);
 
                     requestStats.getRequestStatsLogger(apiKey, KopServerStats.REQUEST_QUEUED_LATENCY)
                             .registerFailedEvent(nanoSecondsSinceCreated, TimeUnit.NANOSECONDS);
@@ -429,7 +432,7 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
                         // It should not be null, just check it for safety
                         log.error("[{}] Unexpected null completed future for request {}",
                                 ctx.channel(), request.getHeader());
-                        sendErrorResponse(request, channel, new ApiException("response is null"));
+                        sendErrorResponse(request, channel, new ApiException("response is null"), true);
                         return;
                     }
                     if (log.isDebugEnabled()) {
@@ -439,7 +442,7 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
                                 this, request, response);
                     }
 
-                    final ByteBuf result = responseToByteBuf(response, request);
+                    final ByteBuf result = responseToByteBuf(response, request, true);
                     final int resultSize = result.readableBytes();
                     channel.writeAndFlush(result).addListener(future -> {
                         if (response instanceof ResponseCallbackWrapper) {
@@ -462,15 +465,17 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
                 log.error("[{}] request {} is not completed for {} ns (> {} ms)",
                         channel, request.getHeader(), nanoSecondsSinceCreated, kafkaConfig.getRequestTimeoutMs());
                 responseFuture.cancel(true);
-                sendErrorResponse(request, channel, new ApiException("request is expired from server side"));
+                sendErrorResponse(request, channel, new ApiException("request is expired from server side"),
+                        false); // we cannot release the request, because the request is still processed somewhere
                 requestStats.getRequestStatsLogger(apiKey, KopServerStats.REQUEST_QUEUED_LATENCY)
                         .registerFailedEvent(nanoSecondsSinceCreated, TimeUnit.NANOSECONDS);
             }
         }
     }
 
-    private void sendErrorResponse(KafkaHeaderAndRequest request, Channel channel, Throwable customError) {
-        ByteBuf result = request.createErrorResponse(customError);
+    private void sendErrorResponse(KafkaHeaderAndRequest request, Channel channel, Throwable customError,
+            boolean releaseRequest) {
+        ByteBuf result = request.createErrorResponse(customError, releaseRequest);
         final int resultSize = result.readableBytes();
         channel.writeAndFlush(result).addListener(future -> {
             if (future.isSuccess()) {
@@ -632,8 +637,9 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
             }
         }
 
-        public ByteBuf createErrorResponse(Throwable e) {
-            return responseToByteBuf(request.getErrorResponse(e), this);
+        public ByteBuf createErrorResponse(Throwable e, boolean release) {
+            return responseToByteBuf(request.getErrorResponse(e), this,
+                    release);
         }
 
         @Override

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -209,6 +209,12 @@ import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 @Getter
 public class KafkaRequestHandler extends KafkaCommandDecoder {
     private static final int THROTTLE_TIME_MS = 10;
+    /**
+     * Request timeout for writes of the TXMARKERS
+     * Writing the TXMARKERS require recovery of the
+     * transactions on the PartitionLog at it may take much time.
+     */
+    private static final int WRITE_TXN_MARKERS_TIMEOUT = 120000;
     private static final String POLICY_ROOT = "/admin/policies/";
 
     private final PulsarService pulsarService;
@@ -2391,7 +2397,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     this::completeSendOperationForThrottling,
                     this.pendingTopicFuturesMap);
             getReplicaManager().appendRecords(
-                    kafkaConfig.getRequestTimeoutMs(),
+                    WRITE_TXN_MARKERS_TIMEOUT,
                     true,
                     currentNamespacePrefix(),
                     controlRecords,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -88,7 +88,7 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
             required = true,
             doc = "The number of threads used to respond to the response."
     )
-    private int numSendKafkaResponseThreads = 4;
+    private int numSendKafkaResponseThreads = 8;
 
     @FieldContext(
         category = CATEGORY_KOP,
@@ -470,6 +470,12 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
             doc = "Interval for purging aborted transactions from memory (requires reads from storage)"
     )
     private int kafkaTxnPurgeAbortedTxnIntervalSeconds = 0;
+
+    @FieldContext(
+            category = CATEGORY_KOP_TRANSACTION,
+            doc = "Number of threads dedicated to transaction recovery"
+    )
+    private int kafkaTransactionRecoveryNumThreads = 8;
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -443,6 +443,12 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,
+            doc = "Flag to enable disable producer state recovery"
+    )
+    private boolean kafkaTransactionStateProducerRecoveryEnabled = true;
+
+    @FieldContext(
+            category = CATEGORY_KOP_TRANSACTION,
             doc = "Number of partitions for the transaction log topic"
     )
     private int kafkaTxnLogTopicNumPartitions = DefaultTxnLogTopicNumPartitions;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -463,13 +463,13 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
             category = CATEGORY_KOP_TRANSACTION,
             doc = "Interval for taking snapshots of the status of pending transactions"
     )
-    private int kafkaTxnProducerStateTopicSnapshotIntervalSeconds = 60;
+    private int kafkaTxnProducerStateTopicSnapshotIntervalSeconds = 10;
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,
             doc = "Interval for purging aborted transactions from memory (requires reads from storage)"
     )
-    private int kafkaTxnPurgeAbortedTxnIntervalSeconds = 60 * 60;
+    private int kafkaTxnPurgeAbortedTxnIntervalSeconds = 0;
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -461,6 +461,12 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,
+            doc = "Interval for purging aborted transactions from memory (requires reads from storage)"
+    )
+    private int kafkaTxnPurgeAbortedTxnIntervalSeconds = 60 * 60;
+
+    @FieldContext(
+            category = CATEGORY_KOP_TRANSACTION,
             doc = "The interval in milliseconds at which to rollback transactions that have timed out."
     )
     private long kafkaTxnAbortTimedOutTransactionCleanupIntervalMs = DefaultAbortTimedOutTransactionsIntervalMs;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -35,6 +35,7 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -133,7 +134,8 @@ public class TransactionCoordinator {
                                             MetadataStoreExtended metadataStore,
                                             KopBrokerLookupManager kopBrokerLookupManager,
                                             ScheduledExecutorService scheduler,
-                                            Time time) throws Exception {
+                                            Time time,
+                                            Executor recoveryExecutor) throws Exception {
         String namespacePrefixForMetadata = MetadataUtils.constructMetadataNamespace(tenant, kafkaConfig);
         String namespacePrefixForUserTopics = MetadataUtils.constructUserTopicsNamespace(tenant, kafkaConfig);
         TransactionStateManager transactionStateManager =
@@ -157,7 +159,7 @@ public class TransactionCoordinator {
                 namespacePrefixForMetadata,
                 namespacePrefixForUserTopics,
                 (config) -> new PulsarTopicProducerStateManagerSnapshotBuffer(
-                        config.getTransactionProducerStateSnapshotTopicName(), txnTopicClient, scheduler)
+                        config.getTransactionProducerStateSnapshotTopicName(), txnTopicClient, recoveryExecutor)
                 );
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -157,7 +157,7 @@ public class TransactionCoordinator {
                 namespacePrefixForMetadata,
                 namespacePrefixForUserTopics,
                 (config) -> new PulsarTopicProducerStateManagerSnapshotBuffer(
-                        config.getTransactionProducerStateSnapshotTopicName(), txnTopicClient)
+                        config.getTransactionProducerStateSnapshotTopicName(), txnTopicClient, scheduler)
                 );
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
@@ -165,10 +165,11 @@ public class TransactionMarkerRequestCompletionHandler implements Consumer<Respo
                         case UNKNOWN_TOPIC_OR_PARTITION:
                         // this error was introduced in newer kafka client version,
                         // recover this condition after bump the kafka client version
-                        // case NOT_LEADER_OR_FOLLOWER:
+                        //case NOT_LEADER_OR_FOLLOWER:
                         case NOT_ENOUGH_REPLICAS:
                         case NOT_ENOUGH_REPLICAS_AFTER_APPEND:
                         case REQUEST_TIMED_OUT:
+                        case UNKNOWN_SERVER_ERROR:
                         case KAFKA_STORAGE_ERROR: // these are retriable errors
                             log.info("Sending {}'s transaction marker for partition {} has failed with error {}, "
                                     + "retrying with current coordinator epoch {}", transactionalId, topicPartition,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -488,7 +488,8 @@ public class PartitionLog {
                     .computeIfAbsent(topicPartition, ignored -> new PendingTopicFutures(requestStats))
                     .addListener(topicFuture, persistentTopicConsumer, appendFuture::completeExceptionally);
         } catch (Exception exception) {
-            log.error("Failed to handle produce request for {}", topicPartition, exception);
+            log.error("Failed to handle write request for {} origin {}",
+                    topicPartition, origin, exception);
             appendFuture.completeExceptionally(exception);
         }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -1071,12 +1071,18 @@ public class PartitionLog {
                     });
 
                     ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) tcm.getManagedLedger();
+                    // this is a DUMMY entry with -1
                     PositionImpl firstPosition = managedLedger.getFirstPosition();
-                    managedLedger.asyncReadEntry(firstPosition, new AsyncCallbacks.ReadEntryCallback() {
+                    // look for the first entry with data
+                    PositionImpl nextValidPosition = managedLedger.getNextValidPosition(firstPosition);
+
+                    managedLedger.asyncReadEntry(nextValidPosition, new AsyncCallbacks.ReadEntryCallback() {
                         @Override
                         public void readEntryComplete(Entry entry, Object ctx) {
                             try {
                                 long startOffset = MessageMetadataUtils.peekBaseOffsetFromEntry(entry);
+                                log.info("First offset for topic {} is {} - position {}", fullPartitionName,
+                                        startOffset, entry.getPosition());
                                 future.complete(startOffset);
                             } catch (Exception err) {
                                 future.completeExceptionally(err);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -115,5 +115,19 @@ public class PartitionLogManager {
         });
         return FutureUtil.waitForAll(handles);
     }
+
+    public CompletableFuture<Void> purgeAbortedTxns() {
+        List<CompletableFuture<Void>> handles = new ArrayList<>();
+        logMap.values().forEach(log -> {
+            if (log.isDone() && !log.isCompletedExceptionally()) {
+                PartitionLog partitionLog = log.getNow(null);
+                if (partitionLog != null) {
+                    handles.add(partitionLog
+                            .purgeAbortedTxns());
+                }
+            }
+        });
+        return FutureUtil.waitForAll(handles);
+    }
 }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -92,7 +92,7 @@ public class PartitionLogManager {
     }
 
     public CompletableFuture<PartitionLog> removeLog(String topicName) {
-        log.info("removeLog", topicName);
+        log.info("removePartionLog {}", topicName);
         return logMap.remove(topicName);
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
@@ -60,19 +60,21 @@ public class ProducerStateManager {
     private CompletableFuture<Void> applySnapshotAndRecover(ProducerStateManagerSnapshot snapshot,
                                                             PartitionLog partitionLog,
                                                             Executor executor) {
-        this.abortedIndexList.clear();
-        this.producers.clear();
-        this.ongoingTxns.clear();
         long offSetPosition = 0;
-        if (snapshot != null) {
-            this.abortedIndexList.addAll(snapshot.getAbortedIndexList());
-            this.producers.putAll(snapshot.getProducers());
-            this.ongoingTxns.putAll(snapshot.getOngoingTxns());
-            this.mapEndOffset = snapshot.getOffset();
-            offSetPosition = snapshot.getOffset();
-            log.info("Recover topic {} from offset {}", topicPartition, offSetPosition);
-        } else {
-            log.info("No snapshot found for topic {}, recovering from the beginning", topicPartition);
+        synchronized (abortedIndexList) {
+            this.abortedIndexList.clear();
+            this.producers.clear();
+            this.ongoingTxns.clear();
+            if (snapshot != null) {
+                this.abortedIndexList.addAll(snapshot.getAbortedIndexList());
+                this.producers.putAll(snapshot.getProducers());
+                this.ongoingTxns.putAll(snapshot.getOngoingTxns());
+                this.mapEndOffset = snapshot.getOffset();
+                offSetPosition = snapshot.getOffset();
+                log.info("Recover topic {} from offset {}", topicPartition, offSetPosition);
+            } else {
+                log.info("No snapshot found for topic {}, recovering from the beginning", topicPartition);
+            }
         }
         long startRecovery = System.currentTimeMillis();
         // recover from log
@@ -98,11 +100,14 @@ public class ProducerStateManager {
 
     public CompletableFuture<ProducerStateManagerSnapshot> takeSnapshot() {
         log.info("Taking snapshot for {} mapEndOffset is {}", topicPartition, mapEndOffset);
-        ProducerStateManagerSnapshot snapshot = new ProducerStateManagerSnapshot(topicPartition,
-                mapEndOffset,
-                new HashMap<>(producers),
-                new TreeMap<>(ongoingTxns),
-                new ArrayList<>(abortedIndexList));
+        ProducerStateManagerSnapshot snapshot;
+        synchronized (abortedIndexList) {
+            snapshot = new ProducerStateManagerSnapshot(topicPartition,
+                    mapEndOffset,
+                    new HashMap<>(producers),
+                    new TreeMap<>(ongoingTxns),
+                    new ArrayList<>(abortedIndexList));
+        }
         return producerStateManagerSnapshotBuffer
                 .write(snapshot)
                 .thenApply(___ -> {
@@ -182,8 +187,10 @@ public class ProducerStateManager {
 
     public void updateTxnIndex(CompletedTxn completedTxn, long lastStableOffset) {
         if (completedTxn.isAborted()) {
-            abortedIndexList.add(new AbortedTxn(completedTxn.producerId(), completedTxn.firstOffset(),
-                    completedTxn.lastOffset(), lastStableOffset));
+            synchronized (abortedIndexList) {
+                abortedIndexList.add(new AbortedTxn(completedTxn.producerId(), completedTxn.firstOffset(),
+                        completedTxn.lastOffset(), lastStableOffset));
+            }
         }
     }
 
@@ -196,15 +203,36 @@ public class ProducerStateManager {
         }
     }
 
-    public List<FetchResponse.AbortedTransaction> getAbortedIndexList(long fetchOffset) {
-        List<FetchResponse.AbortedTransaction> abortedTransactions = new ArrayList<>();
-        for (AbortedTxn abortedTxn : abortedIndexList) {
-            if (abortedTxn.lastOffset() >= fetchOffset) {
-                abortedTransactions.add(
-                        new FetchResponse.AbortedTransaction(abortedTxn.producerId(), abortedTxn.firstOffset()));
+    public boolean hasSomeAbortedTransactions() {
+        return !abortedIndexList.isEmpty();
+    }
+
+    public void purgeAbortedTxns(long offset) {
+        synchronized (abortedIndexList) {
+            abortedIndexList.removeIf(tx -> {
+                boolean toRemove = tx.lastOffset() < offset;
+                if (toRemove) {
+                    log.info("Transaction {} can be removed (lastOffset < {})", tx, tx.lastOffset(), offset);
+                }
+                return toRemove;
+            });
+            if (!abortedIndexList.isEmpty()) {
+                log.info("There are still {} aborted tx on {}", abortedIndexList.size(), topicPartition);
             }
         }
-        return abortedTransactions;
+    }
+
+    public List<FetchResponse.AbortedTransaction> getAbortedIndexList(long fetchOffset) {
+        synchronized (abortedIndexList) {
+            List<FetchResponse.AbortedTransaction> abortedTransactions = new ArrayList<>();
+            for (AbortedTxn abortedTxn : abortedIndexList) {
+                if (abortedTxn.lastOffset() >= fetchOffset) {
+                    abortedTransactions.add(
+                            new FetchResponse.AbortedTransaction(abortedTxn.producerId(), abortedTxn.firstOffset()));
+                }
+            }
+            return abortedTransactions;
+        }
     }
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.errors.NotLeaderOrFollowerException;
 import org.apache.pulsar.client.api.Message;
@@ -45,6 +46,7 @@ public class PulsarTopicProducerStateManagerSnapshotBuffer implements ProducerSt
     private Map<String, ProducerStateManagerSnapshot> latestSnapshots = new ConcurrentHashMap<>();
     private final String topic;
     private final SystemTopicClient pulsarClient;
+    private final Executor executor;
     private CompletableFuture<Reader<ByteBuffer>> reader;
 
     private CompletableFuture<Producer<ByteBuffer>> producer;
@@ -109,10 +111,10 @@ public class PulsarTopicProducerStateManagerSnapshotBuffer implements ProducerSt
                         return CompletableFuture.completedFuture(null);
                     } else {
                         CompletableFuture<Message<ByteBuffer>> opMessage = reader.readNextAsync();
-                        return opMessage.thenCompose(msg -> {
+                        return opMessage.thenComposeAsync(msg -> {
                             processMessage(msg);
                             return readNextMessageIfAvailable(reader);
-                        });
+                        }, executor);
                     }
                 });
     }
@@ -335,9 +337,12 @@ public class PulsarTopicProducerStateManagerSnapshotBuffer implements ProducerSt
         });
     }
 
-    public PulsarTopicProducerStateManagerSnapshotBuffer(String topicName, SystemTopicClient pulsarClient) {
+    public PulsarTopicProducerStateManagerSnapshotBuffer(String topicName,
+            SystemTopicClient pulsarClient,
+            Executor executor) {
         this.topic = topicName;
         this.pulsarClient = pulsarClient;
+        this.executor = executor;
     }
 
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -166,11 +166,13 @@ public class ReplicaManager {
                             .thenAccept(offset -> addPartitionResponse.accept(topicPartition,
                                     new ProduceResponse.PartitionResponse(Errors.NONE, offset, -1L, -1L)))
                             .exceptionally(ex -> {
+                                log.error("Internal error while handling append to {}", fullPartitionName, ex);
                                 addPartitionResponse.accept(topicPartition,
                                         new ProduceResponse.PartitionResponse(Errors.forException(ex.getCause())));
                                 return null;
                             });
                 }).exceptionally(ex -> {
+                    log.error("System error while handling append for {}",fullPartitionName, ex);
                     addPartitionResponse.accept(topicPartition,
                             new ProduceResponse.PartitionResponse(Errors.forException(ex.getCause())));
                     return null;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -286,10 +286,14 @@ public class ReplicaManager {
             log.debug("Request key {} unblocked {} fetch requests.", key.keyLabel(), completed);
         }
     }
-
-
     public CompletableFuture<Void> takeProducerStateSnapshots() {
         return logManager.takeProducerStateSnapshots();
     }
+
+    public CompletableFuture<Void> purgeAbortedTxns() {
+        return logManager.purgeAbortedTxns();
+    }
+
+
 
 }

--- a/kafka-impl/src/test/resources/log4j2.xml
+++ b/kafka-impl/src/test/resources/log4j2.xml
@@ -27,7 +27,7 @@
         <Logger name="org.eclipse.jetty" level="info"/>
         <Logger name="io.streamnative" level="trace"/>
         <Logger name="io.streamnative.pulsar.handlers.kop.format" level="error"/>
-        <Logger name="org.apache.pulsar" level="info"/>
+        <Logger name="org.apache.pulsar" level="debug"/>
         <Logger name="org.apache.bookkeeper" level="info"/>
         <Logger name="org.apache.kafka" level="debug"/>
     </Loggers>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -225,7 +225,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
             kopRequest, apiVersionsResponse);
 
         // 1. serialize response into ByteBuf
-        ByteBuf serializedResponse = KafkaCommandDecoder.responseToByteBuf(kopResponse.getResponse(), kopRequest);
+        ByteBuf serializedResponse = KafkaCommandDecoder.responseToByteBuf(kopResponse.getResponse(), kopRequest, true);
 
         // 2. verify responseToByteBuf works well.
         ByteBuffer byteBuffer = serializedResponse.nioBuffer();


### PR DESCRIPTION
Motivation:
- The Broker (ProducerStateManager) has to keep in memory the list of all the Aborted transactions, in order to report to Consumers the ids and let them skip the records on the client side
- Currently there is no mechanism that removes such list from memory

Modifications:
- Add a periodic job that for every topic that has at least one Aborted Transaction finds the first possible offset and then discards the transactions that are useless (lastOffset < offset)
- In order to get the first available offset we have to read the first available entry of the topic (that may be on offloaded storage if we are using offloaders) and then get the "offset" from that