### PR TITLE
Optimize entry encoding

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Lists;
 import io.netty.buffer.ByteBuf;
 import io.streamnative.pulsar.handlers.kop.utils.PulsarMessageBuilder;
 import java.util.List;
-import java.util.stream.StreamSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.util.MathUtils;
 import org.apache.kafka.common.header.Header;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
@@ -26,6 +26,7 @@ import org.apache.bookkeeper.common.util.MathUtils;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.record.ControlRecordType;
 import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.MutableRecordBatch;
 import org.apache.kafka.common.record.Record;
 import org.apache.pulsar.broker.service.plugin.EntryFilterWithClassLoader;
 import org.apache.pulsar.client.impl.MessageImpl;
@@ -65,16 +66,15 @@ public class PulsarEntryFormatter extends AbstractEntryFormatter {
         List<MessageImpl<byte[]>> messages = Lists.newArrayListWithExpectedSize(numMessages);
         final MessageMetadata msgMetadata = new MessageMetadata();
 
-        records.batches().forEach(recordBatch -> {
-            boolean controlBatch = recordBatch.isControlBatch();
-            StreamSupport.stream(recordBatch.spliterator(), true).forEachOrdered(record -> {
+        for (MutableRecordBatch recordBatch : records.batches()) {
+            for (Record record : recordBatch) {
                 MessageImpl<byte[]> message = recordToEntry(record);
                 messages.add(message);
                 if (recordBatch.isTransactional()) {
                     msgMetadata.setTxnidMostBits(recordBatch.producerId());
                     msgMetadata.setTxnidLeastBits(recordBatch.producerEpoch());
                 }
-                if (controlBatch) {
+                if (recordBatch.isControlBatch()) {
                     ControlRecordType controlRecordType = ControlRecordType.parse(record.key());
                     switch (controlRecordType) {
                         case ABORT:
@@ -88,8 +88,8 @@ public class PulsarEntryFormatter extends AbstractEntryFormatter {
                             break;
                     }
                 }
-            });
-        });
+            }
+        }
 
         for (MessageImpl<byte[]> message : messages) {
             if (++numMessagesInBatch == 1) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
@@ -275,11 +275,12 @@ public class ByteBufUtils {
 
     @NonNull
     private static Header[] getHeadersFromMetadata(final List<KeyValue> properties) {
-        return properties.stream()
-                .map(property -> new RecordHeader(
-                        property.getKey(),
-                        property.getValue().getBytes(UTF_8))
-                ).toArray(Header[]::new);
+        Header[] result = new Header[properties.size()];
+        for (int i = 0; i < properties.size(); i++) {
+            KeyValue property = properties.get(i);
+            result[i] = new RecordHeader(property.getKey(), property.getValue().getBytes(UTF_8));
+        }
+        return result;
     }
 
     private static ByteBuffer prependSchemaId(ByteBuffer original, int schemaId) {


### PR DESCRIPTION
In looking at a JFR, it appears that these Java streams references may be expensive. I'd like to do some performance testing with these changes.

* The first commit is a basic change that should decrease the number of objects required to create the resulting `Header[]`
* The second commit will optimize the code slightly because it will decrease context switching. We might want to explore offloading the encoding task to a different thread pool so that it does not block a netty event loop. That work could be independent of this work.