### PR TITLE
[transactions] A few enhancements and bugfixes

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -657,6 +657,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 .transactionProducerIdTopicName(MetadataUtils.constructTxnProducerIdTopicBaseName(tenant, kafkaConfig))
                 .transactionProducerStateSnapshotTopicName(MetadataUtils.constructTxProducerStateTopicBaseName(tenant,
                         kafkaConfig))
+                .producerStateTopicNumPartitions(kafkaConfig.getKafkaTxnProducerStateTopicNumPartitions())
                 .abortTimedOutTransactionsIntervalMs(kafkaConfig.getKafkaTxnAbortTimedOutTransactionCleanupIntervalMs())
                 .transactionalIdExpirationMs(kafkaConfig.getKafkaTransactionalIdExpirationMs())
                 .removeExpiredTransactionalIdsIntervalMs(

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionConfig.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionConfig.java
@@ -35,6 +35,7 @@ public class TransactionConfig {
     public static final int DefaultTransactionCoordinatorSchedulerNum = 1;
     public static final int DefaultTransactionStateManagerSchedulerNum = 1;
     public static final int DefaultTransactionLogNumPartitions = 8;
+    public static final int DefaultTransactionStateNumPartitions = 8;
 
     @Default
     private int brokerId = 1;
@@ -50,6 +51,9 @@ public class TransactionConfig {
     private long transactionalIdExpirationMs = DefaultTransactionalIdExpirationMs;
     @Default
     private int transactionLogNumPartitions = DefaultTransactionLogNumPartitions;
+
+    @Default
+    private int producerStateTopicNumPartitions = DefaultTransactionStateNumPartitions;
     @Default
     private long abortTimedOutTransactionsIntervalMs = DefaultAbortTimedOutTransactionsIntervalMs;
     @Default

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -27,7 +27,7 @@ import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionMe
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionStateManager.CoordinatorEpochAndTxnMetadata;
 import io.streamnative.pulsar.handlers.kop.scala.Either;
 import io.streamnative.pulsar.handlers.kop.storage.ProducerStateManagerSnapshotBuffer;
-import io.streamnative.pulsar.handlers.kop.storage.PulsarTopicProducerStateManagerSnapshotBuffer;
+import io.streamnative.pulsar.handlers.kop.storage.PulsarPartitionedTopicProducerStateManagerSnapshotBuffer;
 import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
 import io.streamnative.pulsar.handlers.kop.utils.ProducerIdAndEpoch;
 import java.util.Collections;
@@ -158,8 +158,9 @@ public class TransactionCoordinator {
                 time,
                 namespacePrefixForMetadata,
                 namespacePrefixForUserTopics,
-                (config) -> new PulsarTopicProducerStateManagerSnapshotBuffer(
-                        config.getTransactionProducerStateSnapshotTopicName(), txnTopicClient, recoveryExecutor)
+                (config) -> new PulsarPartitionedTopicProducerStateManagerSnapshotBuffer(
+                        config.getTransactionProducerStateSnapshotTopicName(), txnTopicClient, recoveryExecutor,
+                        config.getProducerStateTopicNumPartitions())
                 );
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
@@ -165,7 +165,6 @@ public class TransactionMarkerRequestCompletionHandler implements Consumer<Respo
                         case UNKNOWN_TOPIC_OR_PARTITION:
                         // this error was introduced in newer kafka client version,
                         // recover this condition after bump the kafka client version
-                        //case NOT_LEADER_OR_FOLLOWER:
                         case NOT_ENOUGH_REPLICAS:
                         case NOT_ENOUGH_REPLICAS_AFTER_APPEND:
                         case REQUEST_TIMED_OUT:

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
@@ -406,11 +406,13 @@ public class TransactionStateManager {
                     // note that for timed out request we return NOT_AVAILABLE error code to let client retry
                     return Errors.COORDINATOR_NOT_AVAILABLE;
                 case KAFKA_STORAGE_ERROR:
-//                case Errors.NOT_LEADER_OR_FOLLOWER:
+                case NOT_LEADER_OR_FOLLOWER:
                     return Errors.NOT_COORDINATOR;
                 case MESSAGE_TOO_LARGE:
                 case RECORD_LIST_TOO_LARGE:
                 default:
+                    log.error("Unhandled error code {} for transactionalId {}, return UNKNOWN_SERVER_ERROR",
+                            status.error, transactionalId);
                     return Errors.UNKNOWN_SERVER_ERROR;
             }
         }
@@ -464,7 +466,8 @@ public class TransactionStateManager {
                         metadata.completeTransitionTo(newMetadata);
                         return errors;
                     } catch (IllegalStateException ex) {
-                        log.error("Failed to complete transition.", ex);
+                        log.error("Failed to complete transition for {}. Return UNKNOWN_SERVER_ERROR",
+                                transactionalId, ex);
                         return Errors.UNKNOWN_SERVER_ERROR;
                     }
                 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
@@ -356,8 +356,7 @@ public class SimpleAclAuthorizer implements Authorizer {
 
     @Override
     public CompletableFuture<Boolean> canConsumeAsync(KafkaPrincipal principal, Resource resource) {
-        checkArgument(resource.getResourceType() == ResourceType.TOPIC,
-                String.format("Expected resource type is TOPIC, but have [%s]", resource.getResourceType()));
+        checkArgument(resource.getResourceType() == ResourceType.TOPIC);
         TopicName topicName = TopicName.get(resource.getName());
         return isSuperUserOrTenantAdmin(topicName.getNamespaceObject().getTenant(), principal.getName(), principal)
                 .thenCompose(tenantAdmin -> {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -1139,8 +1139,7 @@ public class PartitionLog {
 
             final long offsetToStart;
             if (checkOffsetOutOfRange(tcm, offset, topicPartition, -1)) {
-                ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) tcm.getManagedLedger();
-                offsetToStart = MessageMetadataUtils.getLogEndOffset(managedLedger);
+                offsetToStart = 0;
                 log.info("recoverTxEntries for {}: offset {} is out-of-range, maybe the topic has been trimmed, "
                          + "starting from {}",
                         topicPartition, offset, offsetToStart);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -92,7 +92,7 @@ public class PartitionLogManager {
     }
 
     public CompletableFuture<PartitionLog> removeLog(String topicName) {
-        log.info("removePartionLog {}", topicName);
+        log.info("removePartitionLog {}", topicName);
         return logMap.remove(topicName);
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -108,7 +108,7 @@ public class PartitionLogManager {
                 if (partitionLog != null) {
                     handles.add(partitionLog
                             .getProducerStateManager()
-                            .takeSnapshot()
+                            .takeSnapshot(recoveryExecutor)
                             .thenApply(___ -> null));
                 }
             }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
@@ -222,11 +222,9 @@ public class ProducerStateManager {
     }
 
     public long purgeAbortedTxns(long offset) {
-        boolean empty;
         AtomicLong count = new AtomicLong();
-        boolean somethingDone;
         synchronized (abortedIndexList) {
-            somethingDone = abortedIndexList.removeIf(tx -> {
+            abortedIndexList.removeIf(tx -> {
                 boolean toRemove = tx.lastOffset() < offset;
                 if (toRemove) {
                     log.info("Transaction {} can be removed (lastOffset < {})", tx, tx.lastOffset(), offset);
@@ -234,8 +232,7 @@ public class ProducerStateManager {
                 }
                 return toRemove;
             });
-            empty = abortedIndexList.isEmpty();
-            if (!empty) {
+            if (!abortedIndexList.isEmpty()) {
                 log.info("There are still {} aborted tx on {}", abortedIndexList.size(), topicPartition);
             }
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarPartitionedTopicProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarPartitionedTopicProducerStateManagerSnapshotBuffer.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.storage;
+
+import io.streamnative.pulsar.handlers.kop.SystemTopicClient;
+import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.common.naming.TopicName;
+
+@Slf4j
+public class PulsarPartitionedTopicProducerStateManagerSnapshotBuffer implements ProducerStateManagerSnapshotBuffer {
+
+    private final List<ProducerStateManagerSnapshotBuffer> partitions = new ArrayList<>();
+
+    private ProducerStateManagerSnapshotBuffer pickPartition(String topic) {
+        return partitions
+                .get(TransactionCoordinator.partitionFor(topic, partitions.size()));
+    }
+
+    @Override
+    public CompletableFuture<Void> write(ProducerStateManagerSnapshot snapshot) {
+        return pickPartition(snapshot.getTopicPartition()).write(snapshot);
+    }
+
+    @Override
+    public CompletableFuture<ProducerStateManagerSnapshot> readLatestSnapshot(String topicPartition) {
+        return pickPartition(topicPartition).readLatestSnapshot(topicPartition);
+    }
+
+    public PulsarPartitionedTopicProducerStateManagerSnapshotBuffer(String topicName,
+                                                                    SystemTopicClient pulsarClient,
+                                                                    Executor executor,
+                                                                    int numPartitions) {
+        TopicName fullName = TopicName.get(topicName);
+        for (int i = 0; i < numPartitions; i++) {
+            PulsarTopicProducerStateManagerSnapshotBuffer partition =
+                    new PulsarTopicProducerStateManagerSnapshotBuffer(
+                            fullName.getPartition(i).toString(),
+                            pulsarClient, executor);
+            partitions.add(partition);
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        partitions.forEach(ProducerStateManagerSnapshotBuffer::shutdown);
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
@@ -13,6 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.kop.storage;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
@@ -78,6 +79,7 @@ public class PulsarTopicProducerStateManagerSnapshotBuffer implements ProducerSt
         }
     }
 
+    @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION")
     private synchronized void discardReader(Reader<ByteBuffer> oldReader) {
         if (reader == null) {
             return;
@@ -142,7 +144,7 @@ public class PulsarTopicProducerStateManagerSnapshotBuffer implements ProducerSt
 
 
     private synchronized CompletableFuture<Void> ensureLatestData(boolean beforeWrite) {
-        if (currentReadHandle != null) {
+        if (currentReadHandle != null && !currentReadHandle.isCompletedExceptionally()) {
             if (beforeWrite) {
                 // we are inside a write loop, so
                 // we must ensure that we start to read now

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
@@ -371,4 +371,9 @@ public class PulsarTopicProducerStateManagerSnapshotBuffer implements ProducerSt
             });
         }
     }
+
+    @Override
+    public String toString() {
+        return "PulsarTopicProducerStateManagerSnapshotBuffer{" + topic + '}';
+    }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -86,10 +86,10 @@ public class ReplicaManager {
         CompletableFuture<PartitionLog> partitionLog = logManager.removeLog(topicName);
         if (log.isDebugEnabled() && partitionLog != null) {
             if (partitionLog.isDone()) {
-                log.debug("PartitionLog: {} has bean removed.", partitionLog);
+                log.debug("PartitionLog: {} has bean removed.", topicName);
             } else {
                 log.error("PartitionLog: {} has bean removed but recovery wasn't finished",
-                        partitionLog);
+                        topicName);
             }
         }
     }


### PR DESCRIPTION
Modfications:

- Remove expensive useless String.format() in canConsumeAsync: This change will save resources on the Fetch path
- take ProducerState snapshots on the threadpool dedicated to recovery (and not in main Pulsar Broker scheduled tasks threadpool: 
This change saves resources on one of the main PulsarBroker threadpools (the main Scheduler), before this change we were taking "snapshots" on that pool, this may have been the cause of HealthChecks failing.

- handle trimmed ledgers (do not throw OffsetOutOfRange in case of trimmed ledger): The OffsetOutOfRange error happens when a topic has been trimmed (or maybe deleted/re-created), and recovery uses a snapshot taken at a offset that is no more valid, in that case we have to read from the latest available offset

- Handle correctly NOT_LEADER_OR_FOLLOWER while writing TX markers: previously it was handled as an UNKNOWN_SERVER_ERROR, preventing graceful recovery