### PR TITLE
[transactions] Reset "pendingState" in case of failures writing to Pulsar 

### DIFF
--- a/docker/testImage/Dockerfile
+++ b/docker/testImage/Dockerfile
@@ -1,4 +1,4 @@
-FROM us-central1-docker.pkg.dev/datastax-gcp-pulsar/pulsar/lunastreaming-all:latest-210
+FROM datastax/lunastreaming-all:2.10_2.10
 USER root
 RUN apt-get update && apt-get -y install openjdk-11-dbg
 RUN rm /pulsar/protocols/*.nar /pulsar/proxyextensions/*.nar

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -331,6 +331,9 @@ public class TransactionCoordinator {
         }
         TxnTransitMetadata newMetadata = errorsOrEpochAndTransitMetadata.getRight().getTxnTransitMetadata();
         if (newMetadata.getTxnState() == PREPARE_EPOCH_FENCE) {
+            log.info("completeInitProducer - Forcing ABORT of transaction {}, producerId {} producerEpoch {}",
+                    transactionalId,
+                    newMetadata.getProducerId(), newMetadata.getProducerEpoch());
             endTransaction(transactionalId,
                     newMetadata.getProducerId(),
                     newMetadata.getProducerEpoch(),
@@ -338,6 +341,7 @@ public class TransactionCoordinator {
                     false,
                     errors -> {
                         if (errors != Errors.NONE) {
+                            log.error("Cannot initProducer {} due to {} error", transactionalId, errors);
                             responseCallback.accept(initTransactionError(errors));
                         } else {
                             log.info("CONCURRENT_TRANSACTIONS: txnId: {} producerId: {} producerEpoch: {} "
@@ -608,6 +612,11 @@ public class TransactionCoordinator {
             return;
         }
 
+        if (!isFromClient) {
+            log.info("endTransaction - before endTxnPreAppend {} metadata {}",
+                    transactionalId, epochAndMetadata.get().getTransactionMetadata());
+        }
+
         Either<Errors, TxnTransitMetadata> preAppendResult = endTxnPreAppend(
                 epochAndMetadata.get(), transactionalId, producerId, isFromClient, producerEpoch,
                 txnMarkerResult, isEpochFence);
@@ -630,6 +639,13 @@ public class TransactionCoordinator {
 
                     @Override
                     public void fail(Errors errors) {
+
+                        if (!isFromClient) {
+                            log.info("endTransaction - AFTER failed appendTransactionToLog {} metadata {}"
+                                            +  "isEpochFence {}",
+                                    transactionalId, epochAndMetadata.get().getTransactionMetadata(), isEpochFence);
+                        }
+
                         log.info("Aborting sending of transaction markers and returning {} error to client for {}'s "
                                 + "EndTransaction request of {}, since appending {} to transaction log with "
                                 + "coordinator epoch {} failed", errors, transactionalId, txnMarkerResult,
@@ -647,6 +663,10 @@ public class TransactionCoordinator {
                             if (epochAndMetadata.getCoordinatorEpoch() == coordinatorEpoch) {
                                     // This was attempted epoch fence that failed, so mark this state on the metadata
                                 epochAndMetadata.getTransactionMetadata().setHasFailedEpochFence(true);
+
+                                // this line is not present in Kafka code base ?
+                                epochAndMetadata.getTransactionMetadata().setPendingState(Optional.empty());
+
                                     log.warn("The coordinator failed to write an epoch fence transition for producer "
                                             + "{} to the transaction log with error {}. The epoch was increased to {} "
                                             + "but not returned to the client", transactionalId, errors,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -517,7 +517,7 @@ public class TransactionCoordinator {
             } else if (txnMetadata.getProducerEpoch() != producerEpoch) {
                 return Either.left(producerEpochFenceErrors());
             } else if (txnMetadata.getPendingState().isPresent()) {
-                log.info("CONCURRENT_TRANSACTIONS: txnId: {} producerId: {} producerEpoch: {} "
+                log.debug("CONCURRENT_TRANSACTIONS: txnId: {} producerId: {} producerEpoch: {} "
                                 + "handleAddPartitionsToTransaction failed. pendingState == {}",
                         txnMetadata.getTransactionalId(), txnMetadata.getProducerId(), txnMetadata.getProducerEpoch(),
                         txnMetadata.getPendingState());

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
@@ -582,6 +582,8 @@ public class TransactionStateManager {
         return CoreUtils.inReadLock(stateLock, () -> {
             int partitionId = partitionFor(transactionalId);
             if (loadingPartitions.contains(partitionId)) {
+                log.info("TX Coordinator {} partition {} for transactionalId {} is loading",
+                        transactionConfig.getTransactionMetadataTopicName(), partitionId, transactionalId);
                 return Either.left(Errors.COORDINATOR_LOAD_IN_PROGRESS);
             } else if (leavingPartitions.contains(partitionId)) {
                 log.info("TX Coordinator {} partition {} for transactionalId {} is unloading",
@@ -590,6 +592,8 @@ public class TransactionStateManager {
             } else {
                 Map<String, TransactionMetadata> metadataMap = transactionMetadataCache.get(partitionId);
                 if (metadataMap == null) {
+                    log.info("TX Coordinator {} partition {} for transactionalId {} is not here",
+                            transactionConfig.getTransactionMetadataTopicName(), partitionId, transactionalId);
                     return Either.left(Errors.NOT_COORDINATOR);
                 }
 
@@ -748,6 +752,8 @@ public class TransactionStateManager {
                 for (Map.Entry<String, TransactionMetadata> entry : loadedTransactions.entrySet()) {
                     TransactionMetadata txnMetadata = entry.getValue();
                     txnMetadata.inLock(() -> {
+                        log.info("{} found TX {} state {} missing partitions {}",
+                                entry.getKey(), txnMetadata.getState(), txnMetadata.getTopicPartitions());
                         switch (txnMetadata.getState()) {
                             case PREPARE_ABORT:
                                 transactionsPendingForCompletion.add(
@@ -780,6 +786,9 @@ public class TransactionStateManager {
                 loadingPartitions.remove(topicPartition.partition());
 
                 transactionsPendingForCompletion.forEach(pendingTxn -> {
+                    log.info("{} recover send markers result {} for {}", topicPartition,
+                            pendingTxn.result,
+                            pendingTxn.txnMetadata.getTransactionalId());
                     sendTxnMarkersCallback.send(pendingTxn.result, pendingTxn.txnMetadata, pendingTxn.transitMetadata);
                 });
             }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
@@ -90,6 +91,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
     private final int coordinatorEpoch = 0;
 
     private final Consumer<TransactionCoordinator.InitProducerIdResult> initProducerIdMockCallback = (ret) -> {
+        log.info("Result {}", ret);
         result = ret;
     };
 
@@ -1053,6 +1055,20 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
 
     @Test(timeOut = defaultTestTimeout)
     public void shouldAbortTransactionOnHandleInitPidWhenExistingTransactionInOngoingState() {
+        shouldAbortTransactionOnHandleInitPidWhenExistingTransactionInOngoingState(false);
+    }
+
+    @Test(timeOut = defaultTestTimeout)
+    public void shouldAbortTransactionOnHandleInitPidWhenExistingTransactionInOngoingStateWithPulsarError() {
+        shouldAbortTransactionOnHandleInitPidWhenExistingTransactionInOngoingState(true);
+    }
+
+    private void shouldAbortTransactionOnHandleInitPidWhenExistingTransactionInOngoingState(
+            boolean injectPulsarWriterError) {
+        AtomicReference<Errors> appendError = new AtomicReference<>();
+        if (injectPulsarWriterError) {
+            appendError.set(Errors.BROKER_NOT_AVAILABLE);
+        }
         TransactionMetadata txnMetadata = TransactionMetadata.builder()
                 .transactionalId(transactionalId)
                 .producerId(producerId)
@@ -1088,7 +1104,11 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
                 .txnLastUpdateTimestamp(time.milliseconds())
                 .build();
         doAnswer((__) -> {
-            capturedErrorsCallback.getValue().complete();
+            if (appendError.get() != null) {
+                capturedErrorsCallback.getValue().fail(appendError.get());
+            } else {
+                capturedErrorsCallback.getValue().complete();
+            }
             return null;
         }).when(transactionManager)
                 .appendTransactionToLog(
@@ -1099,11 +1119,20 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
                         any(TransactionStateManager.RetryOnError.class)
                 );
         transactionCoordinator
-                .handleInitProducerId(transactionalId, txnTimeoutMs, Optional.empty(), initProducerIdMockCallback);
-        assertEquals(new TransactionCoordinator.InitProducerIdResult(
-                -1L,
-                (short) -1,
-                Errors.CONCURRENT_TRANSACTIONS), result);
+                .handleInitProducerId(transactionalId, txnTimeoutMs, Optional.empty(),
+                        initProducerIdMockCallback);
+        if (injectPulsarWriterError) {
+            assertEquals(new TransactionCoordinator.InitProducerIdResult(
+                    -1L,
+                    (short) -1,
+                    Errors.BROKER_NOT_AVAILABLE), result);
+            appendError.set(null);
+        } else {
+            assertEquals(new TransactionCoordinator.InitProducerIdResult(
+                    -1L,
+                    (short) -1,
+                    Errors.CONCURRENT_TRANSACTIONS), result);
+        }
         verify(transactionManager, atLeastOnce()).validateTransactionTimeoutMs(anyInt());
         verify(transactionManager, atLeastOnce()).appendTransactionToLog(
                 eq(transactionalId),
@@ -1111,6 +1140,19 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
                 any(TransactionMetadata.TxnTransitMetadata.class),
                 capturedErrorsCallback.capture(),
                 any(TransactionStateManager.RetryOnError.class));
+
+        // state must be still ONGOING because markers are sent asynchronously
+        // and in this test we are not sending them
+        assertEquals(txnMetadata.getState(), TransactionState.ONGOING);
+
+        if (injectPulsarWriterError) {
+            // transaction state should not be modified
+            assertTrue(txnMetadata.getPendingState().isEmpty());
+        } else {
+            // abort will be in progress
+            assertTrue(txnMetadata.getPendingState().isPresent());
+            assertEquals(txnMetadata.getPendingState().get(), TransactionState.PREPARE_ABORT);
+        }
     }
 
     @Test(timeOut = defaultTestTimeout)


### PR DESCRIPTION
Motivation:

In S4K we store the state of the Transactions on a Pulsar topic and not on the local disk.
A failure in writing to the transaction-state topic can be considered "temporary" due to the natural self-healing nature of Pulsar (brokers and storage).

When a new Producer executes initTransactions() (that maps to the initProducer request) we have to ABORT the previous transaction for the producer.
In may happen that there is a (temporary) failure writing the new state of the transaction to the transaction-state topic: in that case the transaction remains with a "PendingState" (PREPARE_ABORT).
As the state of the TransactionMetadata is "dirty" if the Producer issues again the initProducer request, that is deemed to fail with CONCURRENT_TRANSACTIONS forever (probably restarting the broker may have a self healing effect as the in memory state will be recovered, but asking to restart a broker is not a good answer to the problem)

Solution:
Reset the "pendingState" of the TransactionMetadata

Why in Kafka they are not doing the same ?

Probably in Kafka when you have a local storage failure you are going to restart the Broker in any case ? The decoupled nature of Pulsar is adding some complexity (but that's also the source of the added elasticity and improved resilience)