### PR TITLE
[transactions] Use a UUID in order to distinguish deleted/created topics

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -133,7 +134,8 @@ public class AdminManager {
                 }
                 return;
             }
-            admin.topics().createPartitionedTopicAsync(kopTopic.getFullName(), numPartitions)
+            admin.topics().createPartitionedTopicAsync(kopTopic.getFullName(), numPartitions,
+                            Map.of("kafkaTopicUUID", UUID.randomUUID().toString()))
                     .whenComplete((ignored, e) -> {
                         if (e == null) {
                             if (log.isDebugEnabled()) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -66,6 +66,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -567,7 +568,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                             } else {
                                 log.info("[{}] Topic {} doesn't exist, auto create it with {} partitions",
                                         ctx.channel(), topicName, defaultNumPartitions);
-                                admin.topics().createPartitionedTopicAsync(topicName, defaultNumPartitions)
+                                admin.topics().createPartitionedTopicAsync(topicName, defaultNumPartitions,
+                                                Map.of("kafkaTopicUUID", UUID.randomUUID().toString()))
                                         .whenComplete((__, createException) -> {
                                             if (createException == null) {
                                                 future.complete(defaultNumPartitions);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionWithOAuthBearerAuthTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionWithOAuthBearerAuthTest.java
@@ -84,6 +84,13 @@ public class TransactionWithOAuthBearerAuthTest extends TransactionTest {
     }
 
     @Override
+    protected Properties newKafkaAdminClientProperties() {
+        final Properties adminProps = super.newKafkaAdminClientProperties();
+        addCustomizeProps(adminProps);
+        return adminProps;
+    }
+
+    @Override
     protected void addCustomizeProps(Properties properties) {
         properties.setProperty("sasl.login.callback.handler.class", OauthLoginCallbackHandler.class.getName());
         properties.setProperty("security.protocol", "SASL_PLAINTEXT");


### PR DESCRIPTION
Motivation:
- currently there is no way to determinate if a topic is deleted/recreated
- on the ProducerState snapshots we risk to interpret a snapshot taken from the old life of the topic as good for the new life

Modifications:
- tag the topics created using the Kafka APIs (admin + auto creation) with a kafkaTopicUUID property
- use the kafkaTopicUUID as key for the snapshots (actually it is the UUID + the full partition name)
- refactor the PartitionLog lifecycle in order to load the topic properties at boot, that simplifies a lot also the loading of entryFormatter
