### PR TITLE
[proxy] Initial Support for OAUTHBEARER authentication between Proxy and Broker

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -195,6 +195,7 @@ public class SaslAuthenticator {
         this.oauth2CallbackHandler = allowedMechanisms.contains(OAuthBearerLoginModule.OAUTHBEARER_MECHANISM)
                 ? createOAuth2CallbackHandler(config) : null;
         this.enableKafkaSaslAuthenticateHeaders = false;
+        this.defaultKafkaMetadataTenant = config.getKafkaMetadataTenant();
     }
 
     public void authenticate(ChannelHandlerContext ctx,
@@ -602,9 +603,8 @@ public class SaslAuthenticator {
                     null);
             return mechanism;
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("SASL mechanism '{}' requested by client is not supported", mechanism);
-            }
+            log.error("SASL mechanism '{}' requested by client is not supported, only {}",
+                        mechanism, allowedMechanisms);
             registerRequestLatency.accept(header.apiKey(), startProcessTime);
             buildResponseOnAuthenticateFailure(header, request,
                     KafkaResponseUtils.newSaslHandshake(Errors.UNSUPPORTED_SASL_MECHANISM, allowedMechanisms),

--- a/proxy/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProxyRequestHandler.java
+++ b/proxy/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProxyRequestHandler.java
@@ -147,8 +147,6 @@ import org.apache.pulsar.broker.authorization.AuthorizationService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Authentication;
-import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.client.impl.AuthenticationUtil;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.FutureUtil;
 
@@ -164,7 +162,7 @@ public class KafkaProxyRequestHandler extends KafkaCommandDecoder {
     private final SaslAuthenticator authenticator;
     private final Authorizer authorizer;
     // this is for Proxy -> Broker authentication
-    private final Authentication authenticationToken;
+    private final Authentication authentication;
     private final boolean tlsEnabled;
     private final EndPoint advertisedEndPoint;
     private final String advertisedListeners;
@@ -179,6 +177,7 @@ public class KafkaProxyRequestHandler extends KafkaCommandDecoder {
                                     AuthenticationService authenticationService,
                                     AuthorizationService authorizationService,
                                     KafkaServiceConfiguration kafkaConfig,
+                                    Authentication authentication,
                                     boolean tlsEnabled,
                                     EndPoint advertisedEndPoint,
                                     Function<String, String> brokerAddressMapper,
@@ -190,9 +189,7 @@ public class KafkaProxyRequestHandler extends KafkaCommandDecoder {
         this.workerGroup = workerGroup;
         this.brokerAddressMapper = brokerAddressMapper;
         this.id = id;
-        String auth = kafkaConfig.getBrokerClientAuthenticationPlugin();
-        String authParams = kafkaConfig.getBrokerClientAuthenticationParameters();
-        this.authenticationToken = AuthenticationUtil.create(auth, authParams);
+        this.authentication = authentication;
 
         this.admin = pulsarAdmin;
         final boolean authenticationEnabled = kafkaConfig.isAuthenticationEnabled();
@@ -1979,8 +1976,8 @@ public class KafkaProxyRequestHandler extends KafkaCommandDecoder {
         keysToRemove.forEach(topicsLeaders::remove);
     }
 
-    String getClientToken() throws PulsarClientException {
-        return authenticationToken.getAuthData().getCommandData();
+    Authentication getAuthentication() {
+        return authentication;
     }
 
     /**

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthDefaultHandlersProxyTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthDefaultHandlersProxyTest.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import com.google.common.collect.Sets;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
+import org.apache.pulsar.client.impl.auth.AuthenticationToken;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+/**
+ * Same as {@link SaslOAuthDefaultHandlersTest} but with proxy.
+ */
+@Slf4j
+public class SaslOAuthDefaultHandlersProxyTest extends SaslOAuthDefaultHandlersTest {
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.setup();
+        startProxy();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        stopProxy();
+        super.cleanup();
+    }
+
+    @Override
+    protected void overrideBrokerConfig(KafkaServiceConfiguration conf) {
+        // setup PROXY connection for broker
+        conf.setSuperUserRoles(Sets.newHashSet(ADMIN_USER, PROXY_USER));
+        conf.setProxyRoles(Sets.newHashSet(PROXY_USER));
+        // proxy -> broker authentication is with PLAIN
+        conf.setSaslAllowedMechanisms(Sets.newHashSet("OAUTHBEARER", "PLAIN"));
+    }
+
+    @Override
+    protected void prepareProxyConfiguration(Properties config) throws Exception {
+        config.put("authenticationEnabled", conf.isAuthenticationEnabled() + "");
+        config.put("authorizationEnabled", conf.isAuthorizationEnabled() + "");
+        // proxy supports only OAUTHBEARER
+        config.put("saslAllowedMechanisms", "OAUTHBEARER");
+        config.put("kopOauth2ConfigFile", conf.getKopOauth2ConfigFile());
+        config.put("kopOauth2Properties", conf.getKopOauth2Properties());
+        if (conf.getKopOauth2AuthenticateCallbackHandler() != null) {
+            config.put("kopOauth2AuthenticateCallbackHandler", conf.getKopOauth2AuthenticateCallbackHandler());
+        }
+        config.put("kafkaProxySuperUserRole", ADMIN_USER);
+
+        config.put("authenticationProviders", conf.getAuthenticationProviders().stream().collect(Collectors.joining()));
+
+        // PROXY -> BROKER uses PLAIN authentication with JWT
+        // the Proxy must use a proxy token
+        config.put("brokerClientAuthenticationPlugin", AuthenticationToken.class.getName());
+        config.put("brokerClientAuthenticationParameters",
+                AuthTokenUtils.createToken(secretKey, PROXY_USER, Optional.empty()));
+    }
+
+    protected int getClientPort() {
+        return getKafkaProxyPort();
+    }
+
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthDefaultHandlersTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthDefaultHandlersTest.java
@@ -39,8 +39,12 @@ import org.testng.annotations.Test;
 @Slf4j
 public class SaslOAuthDefaultHandlersTest extends SaslOAuthBearerTestBase {
 
-    private static final String ADMIN_USER = "admin_user";
-    private static final String USER = "user";
+    protected static final String ADMIN_USER = "admin_user";
+
+    protected static final String PROXY_USER = "proxy_user";
+    protected static final String USER = "user";
+
+    protected SecretKey secretKey;
 
     @BeforeClass
     @Override
@@ -51,7 +55,7 @@ public class SaslOAuthDefaultHandlersTest extends SaslOAuthBearerTestBase {
         conf.setAuthenticationProviders(Sets.newHashSet(AuthenticationProviderToken.class.getName()));
 
         conf.setBrokerClientAuthenticationPlugin(AuthenticationToken.class.getName());
-        final SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
+        secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
         conf.setBrokerClientAuthenticationParameters(
                 "token:" + AuthTokenUtils.createToken(secretKey, ADMIN_USER, Optional.empty()));
         conf.setSuperUserRoles(Sets.newHashSet(ADMIN_USER));
@@ -61,6 +65,9 @@ public class SaslOAuthDefaultHandlersTest extends SaslOAuthBearerTestBase {
 
         conf.setSaslAllowedMechanisms(Sets.newHashSet("OAUTHBEARER"));
         conf.setKopOauth2ConfigFile("src/test/resources/kop-default-oauth2.properties");
+
+        overrideBrokerConfig(conf);
+
         super.internalSetup();
 
         admin.namespaces().grantPermissionOnNamespace(
@@ -68,6 +75,9 @@ public class SaslOAuthDefaultHandlersTest extends SaslOAuthBearerTestBase {
                 USER,
                 Sets.newHashSet(AuthAction.consume, AuthAction.produce)
         );
+    }
+
+    protected void overrideBrokerConfig(KafkaServiceConfiguration conf) {
     }
 
     @AfterClass

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthKopHandlersProxyTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthKopHandlersProxyTest.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import com.google.common.collect.Sets;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Same as {@link SaslOAuthKopHandlersTest} but using the proxy.
+ *
+ * Proxy -> Broker AUTH is with OAUTH2
+ */
+@Slf4j
+public class SaslOAuthKopHandlersProxyTest extends SaslOAuthKopHandlersTest {
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.setup();
+        startProxy();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        stopProxy();
+        super.cleanup();
+    }
+
+    @Override
+    protected void overrideBrokerConfig(KafkaServiceConfiguration conf) {
+        // setup PROXY connection for broker
+        conf.setSuperUserRoles(Sets.newHashSet(ADMIN_USER, PROXY_USER));
+        conf.setProxyRoles(Sets.newHashSet(PROXY_USER));
+        // proxy -> broker authentication is with OAUTHBEARER
+    }
+
+    @Override
+    protected void prepareProxyConfiguration(Properties config) throws Exception {
+        config.put("authenticationEnabled", conf.isAuthenticationEnabled() + "");
+        config.put("authorizationEnabled", conf.isAuthorizationEnabled() + "");
+        // proxy supports only OAUTHBEARER
+        config.put("saslAllowedMechanisms", "OAUTHBEARER");
+        config.put("kopOauth2ConfigFile", conf.getKopOauth2ConfigFile());
+        config.put("kopOauth2Properties", conf.getKopOauth2Properties());
+        if (conf.getKopOauth2AuthenticateCallbackHandler() != null) {
+            config.put("kopOauth2AuthenticateCallbackHandler", conf.getKopOauth2AuthenticateCallbackHandler());
+        }
+        config.put("kafkaProxySuperUserRole", ADMIN_USER);
+
+        config.put("authenticationProviders", conf.getAuthenticationProviders().stream().collect(Collectors.joining()));
+
+        // PROXY -> BROKER uses OAUTHBEARER
+        config.put("brokerClientAuthenticationPlugin", AuthenticationOAuth2.class.getName());
+        config.put("brokerClientAuthenticationParameters", String.format("{\"type\":\"client_credentials\","
+                        + "\"privateKey\":\"%s\",\"issuerUrl\":\"%s\",\"audience\":\"%s\"}",
+                proxyCredentialPath, ISSUER_URL, AUDIENCE));
+    }
+
+    protected int getClientPort() {
+        return getKafkaProxyPort();
+    }
+
+    @Test(enabled = false)
+    public void testGrantAndRevokePermission() throws Exception {
+    }
+
+    @Test(enabled = false)
+    public void testAuthenticationHasException() throws Exception {
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthKopHandlersTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthKopHandlersTest.java
@@ -78,18 +78,25 @@ import org.testng.annotations.Test;
 @Slf4j
 public class SaslOAuthKopHandlersTest extends SaslOAuthBearerTestBase {
 
-    private static final String ADMIN_USER = "simple_client_id";
+    protected static final String ADMIN_USER = "simple_client_id";
+
+    protected static final String PROXY_USER = "proxy_id";
+
     private static final String ADMIN_SECRET = "admin_secret";
-    private static final String ISSUER_URL = "http://localhost:4444";
-    private static final String AUDIENCE = "http://example.com/api/v2/";
+
+    protected static final String PROXY_SECRET = "proxy_secret";
+    protected static final String ISSUER_URL = "http://localhost:4444";
+    protected static final String AUDIENCE = "http://example.com/api/v2/";
 
     private String adminCredentialPath = null;
+    protected String proxyCredentialPath = null;
 
     @BeforeClass(timeOut = 20000)
     @Override
     protected void setup() throws Exception {
         String tokenPublicKey = HydraOAuthUtils.getPublicKeyStr();
         adminCredentialPath = HydraOAuthUtils.createOAuthClient(ADMIN_USER, ADMIN_SECRET);
+        proxyCredentialPath = HydraOAuthUtils.createOAuthClient(PROXY_USER, PROXY_SECRET);
         super.resetConfig();
         // Broker's config
         conf.setAuthenticationEnabled(true);
@@ -109,7 +116,12 @@ public class SaslOAuthKopHandlersTest extends SaslOAuthBearerTestBase {
         conf.setKopOauth2AuthenticateCallbackHandler(OauthValidatorCallbackHandler.class.getName());
         conf.setKopOauth2ConfigFile("src/test/resources/kop-handler-oauth2.properties");
 
+        overrideBrokerConfig(conf);
+
         super.internalSetup();
+    }
+
+    protected void overrideBrokerConfig(KafkaServiceConfiguration conf) {
     }
 
     @AfterClass
@@ -281,7 +293,8 @@ public class SaslOAuthKopHandlersTest extends SaslOAuthBearerTestBase {
                                                       AuthenticationDataSource authenticationData,
                                                       ServiceConfiguration serviceConfiguration) {
             try {
-                return CompletableFuture.completedFuture(role.equals(ADMIN_USER));
+                return CompletableFuture.completedFuture(role.equals(ADMIN_USER)
+                        || role.equals(PROXY_USER));
             } catch (NullPointerException e) {
                 NULL_ROLE_STACKS.addAll(Arrays.asList(e.getStackTrace()));
                 return CompletableFuture.completedFuture(true);


### PR DESCRIPTION
Motivation:
- add initial support for OAUTHBEARER authentication between proxy and broken

Modifications:
- apply some changes from TransationChannelManager to ConnectioToBroker (proxy -> broker communications)
- add test cases: PROXY -> BROKER with TOKEN and PROXY -> BROKER with OAUTH2

Notes:
the OAUTHBEARER authentication between proxy and broker doesn't carry the "role" information currently so basically all the operations from the proxy as executed using the "role" of the proxy.
For this reason this implementation can be considered only a "prototype"

Please also note that you could still enable JWT token authentication between Proxy and the Broker (see the test cases), in that case the Proxy is able to pass the original principal to the Broker and so the Broker users the client permissions to operate on the data
