### PR TITLE
Update Pulsar version to Luna Streaming 2.10.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <lombok.version>1.18.24</lombok.version>
     <mockito.version>2.22.0</mockito.version>
     <pulsar.group.id>com.datastax.oss</pulsar.group.id>
-    <pulsar.version>2.10.0.5</pulsar.version>
+    <pulsar.version>2.10.3.0</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <spotbugs-annotations.version>3.1.12</spotbugs-annotations.version>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/docker/DockerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/docker/DockerTest.java
@@ -28,8 +28,8 @@ import org.testng.annotations.Test;
 @Slf4j
 public class DockerTest {
 
-    private static final String IMAGE_LUNASTREAMING210 = "datastax/lunastreaming:2.10_2.9";
-    private static final String IMAGE_PULSAR210 = "apachepulsar/pulsar:2.10.1";
+    private static final String IMAGE_LUNASTREAMING210 = "datastax/lunastreaming:2.10_3.0";
+    private static final String IMAGE_PULSAR210 = "apachepulsar/pulsar:2.10.3";
     private static final String CONFLUENT_CLIENT = "confluentinc/cp-kafka:latest";
     private static final String CONFLUENT_SCHEMAREGISTRY_CLIENT = "confluentinc/cp-schema-registry:latest";
 


### PR DESCRIPTION
Motivation:
- we have to keep the LS dependency up-to-date
- LS 2.10.3 contains some improvements to broker shutdown, in particular the PH will be closed before stopping the BrokerService now, and that will help in having a more graceful teardown of the unit tests