### PR TITLE
[performance] Serialisation improvements after migration to 2.8.x Kafka client

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
@@ -221,6 +221,10 @@ public class ByteBufUtils {
                 if (valueSchemaId >= 0) {
                     value = prependSchemaId(value, valueSchemaId);
                 }
+
+                keyByteBuffer = ensureOnHeap(keyByteBuffer);
+                value = ensureOnHeap(value);
+
                 if (magic >= RecordBatch.MAGIC_VALUE_V2) {
                     final Header[] headers = getHeadersFromMetadata(singleMessageMetadata.getPropertiesList());
                     builder.appendWithOffset(baseOffset + i,
@@ -271,6 +275,17 @@ public class ByteBufUtils {
                 directBufferOutputStream.getByteBuf(),
                 conversionCount,
                 MathUtils.elapsedNanos(startConversionNanos));
+    }
+
+    private static ByteBuffer ensureOnHeap(ByteBuffer value) {
+        if (value != null && !value.hasArray()) {
+            byte[] arr = new byte[value.remaining()];
+            value.get(arr);
+            value = ByteBuffer.wrap(arr);
+            return value;
+        } else {
+            return value;
+        }
     }
 
     @NonNull

--- a/kafka-impl/src/main/java/org/apache/kafka/common/requests/KopResponseUtils.java
+++ b/kafka-impl/src/main/java/org/apache/kafka/common/requests/KopResponseUtils.java
@@ -16,7 +16,11 @@ package org.apache.kafka.common.requests;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufOutputStream;
 import java.io.DataOutputStream;
+import java.nio.ByteBuffer;
+
+import io.netty.buffer.Unpooled;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Message;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
 import org.apache.kafka.common.protocol.Writable;
@@ -60,14 +64,12 @@ public class KopResponseUtils {
 
         int headerSize = header.size(cache, headerVersion);
         int messageSize = apiMessage.size(cache, apiVersion);
-        ByteBuf result = PulsarByteBufAllocator.DEFAULT.directBuffer(headerSize + messageSize);
-
-        Writable writable = new KopDataOutputStreamWritable(new DataOutputStream(new ByteBufOutputStream(result)));
-
+        ByteBuffer result = ByteBuffer.allocate(headerSize + messageSize);
+        ByteBufferAccessor writable = new ByteBufferAccessor(result);
         header.write(writable, cache, headerVersion);
         apiMessage.write(writable, cache, apiVersion);
-
-        return result;
+        result.flip();
+        return Unpooled.wrappedBuffer(result);
     }
 
 }

--- a/kafka-impl/src/main/java/org/apache/kafka/common/requests/KopResponseUtils.java
+++ b/kafka-impl/src/main/java/org/apache/kafka/common/requests/KopResponseUtils.java
@@ -14,17 +14,12 @@
 package org.apache.kafka.common.requests;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufOutputStream;
-import java.io.DataOutputStream;
-import java.nio.ByteBuffer;
-
 import io.netty.buffer.Unpooled;
+import java.nio.ByteBuffer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Message;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
-import org.apache.kafka.common.protocol.Writable;
-import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 
 /**
  * Provide util classes to access protected fields in kafka structures.


### PR DESCRIPTION
Modifications:
1) ensure that key/values are on the heap (see below)
2) do not use DataOutputStream (see below)


### ensure that key/values are on the heap

From the flamegraph it is clear that the Kafka encoder calls too many times `writeByte(byte)` on DirectBufferOutputStream.
This happens because we pass a DirectByteBuffer for the "value"

This is the code of Utils.writeTo() 
```
public static void writeTo(DataOutput out, ByteBuffer buffer, int length) throws IOException {
        if (buffer.hasArray()) {
            out.write(buffer.array(), buffer.position() + buffer.arrayOffset(), length);
        } else {
            int pos = buffer.position();
            for (int i = pos; i < length + pos; i++)
                out.writeByte(buffer.get(i));
        }
    }
```

<img width="1704" alt="image" src="https://user-images.githubusercontent.com/9469110/213156999-dbc21df8-340b-4869-a43e-c97db7e5f493.png">


### do not use DataOutputStream
Serialising using DataOutputStream leads to wasting many CPU cycles and preventing quick "arraycopy" operations.
The original Kafka code uses an Heap Buffer
https://github.com/apache/kafka/blob/9361a43cfa07ab8589336ddf831070284099be62/clients/src/main/java/org/apache/kafka/common/requests/RequestUtils.java#L72

it seems from the flamegraphs that the best results are using the original approach.
We give up on using pooled buffers and direct memory, but Kafka serialisation code used to work that way

![image](https://user-images.githubusercontent.com/9469110/213683311-c0c0fe9b-9779-4dbf-9be1-121ab10bfb49.png)
