### PR TITLE
[performance] Remove dummy 10ms throttling on FetchResponse

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -1676,7 +1676,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                 new FetchResponse<>(
                                     Errors.NONE,
                                     partitions,
-                                    THROTTLE_TIME_MS,
+                                    0,
                                     request.metadata().sessionId()),
                                 () -> resultMap.forEach((__, readRecordsResult) -> {
                                     readRecordsResult.recycle();


### PR DESCRIPTION
Since the upgrade of the Kafka client library to 2.8.x we introduced a forced delay of 10ms on  every FetchResponse.

