### PR TITLE
[fix] Preserve ordering of writes when Transaction recovery kicks in

### DIFF
--- a/docker/testImage/Dockerfile
+++ b/docker/testImage/Dockerfile
@@ -1,4 +1,4 @@
-FROM datastax/lunastreaming-all:2.10_2.11
+FROM datastax/lunastreaming-all:2.10_3.1
 USER root
 RUN apt-get update && apt-get -y install openjdk-11-dbg
 RUN rm /pulsar/protocols/*.nar /pulsar/proxyextensions/*.nar

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedFetch.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedFetch.java
@@ -107,9 +107,11 @@ public class DelayedFetch extends DelayedOperation {
             return true;
         }
         for (Map.Entry<TopicPartition, PartitionLog.ReadRecordsResult> entry : readRecordsResult.entrySet()) {
-            TopicPartition tp = entry.getKey();
             PartitionLog.ReadRecordsResult result = entry.getValue();
             PartitionLog partitionLog = result.partitionLog();
+            if (partitionLog == null) {
+                return true;
+            }
             PositionImpl currLastPosition = (PositionImpl) partitionLog.getLastPosition();
             if (currLastPosition.compareTo(PositionImpl.EARLIEST) == 0) {
                 HAS_ERROR_UPDATER.set(this, true);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedFetch.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedFetch.java
@@ -110,7 +110,7 @@ public class DelayedFetch extends DelayedOperation {
             TopicPartition tp = entry.getKey();
             PartitionLog.ReadRecordsResult result = entry.getValue();
             PartitionLog partitionLog = result.partitionLog();
-            PositionImpl currLastPosition = (PositionImpl) partitionLog.getLastPosition(context.getTopicManager());
+            PositionImpl currLastPosition = (PositionImpl) partitionLog.getLastPosition();
             if (currLastPosition.compareTo(PositionImpl.EARLIEST) == 0) {
                 HAS_ERROR_UPDATER.set(this, true);
                 return forceComplete();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -16,7 +16,6 @@ package io.streamnative.pulsar.handlers.kop;
 import java.net.SocketAddress;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarService;
@@ -123,10 +122,10 @@ public class KafkaTopicManager {
             }
             return Optional.empty();
         }
-        ConcurrentHashMap<KafkaRequestHandler, Producer> references = requestHandler
-                .getKafkaTopicManagerSharedState().getReferences();
-        return Optional.of(references.computeIfAbsent(requestHandler,
-                (__) -> registerInPersistentTopic(persistentTopic)));
+        return requestHandler
+                .getKafkaTopicManagerSharedState()
+                .registerProducer(topicName, requestHandler,
+                        () -> registerInPersistentTopic(persistentTopic));
     }
 
     // when channel close, release all the topics reference in persistentTopic

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -123,9 +123,10 @@ public class KafkaTopicManager {
             }
             return Optional.empty();
         }
-        ConcurrentHashMap<String, Producer> references = requestHandler
+        ConcurrentHashMap<KafkaRequestHandler, Producer> references = requestHandler
                 .getKafkaTopicManagerSharedState().getReferences();
-        return Optional.of(references.computeIfAbsent(topicName, (__) -> registerInPersistentTopic(persistentTopic)));
+        return Optional.of(references.computeIfAbsent(requestHandler,
+                (__) -> registerInPersistentTopic(persistentTopic)));
     }
 
     // when channel close, release all the topics reference in persistentTopic
@@ -153,8 +154,6 @@ public class KafkaTopicManager {
             }
             CompletableFuture<Optional<PersistentTopic>> topicCompletableFuture =
                     kafkaTopicLookupService.getTopic(topicName, requestHandler.ctx.channel());
-            // cache for removing producer
-            requestHandler.getKafkaTopicManagerSharedState().getTopics().put(topicName, topicCompletableFuture);
             return topicCompletableFuture;
         } catch (Throwable error) {
             log.error("Unhandled error here for {}", topicName, error);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManagerSharedState.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManagerSharedState.java
@@ -80,8 +80,10 @@ public final class KafkaTopicManagerSharedState {
     private void removePersistentTopicAndReferenceProducer(final KafkaRequestHandler producerId) {
         // 1. Remove PersistentTopic and Producer from caches, these calls are thread safe
         final Producer producer = references.remove(producerId);
-        PersistentTopic topic = (PersistentTopic) producer.getTopic();
-        topic.removeProducer(producer);
+        if (producer != null) {
+            PersistentTopic topic = (PersistentTopic) producer.getTopic();
+            topic.removeProducer(producer);
+        }
     }
 
     public void handlerKafkaRequestHandlerClosed(SocketAddress remoteAddress, KafkaRequestHandler requestHandler) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/PendingTopicFutures.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/PendingTopicFutures.java
@@ -14,7 +14,7 @@
 package io.streamnative.pulsar.handlers.kop;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.Optional;
+import io.streamnative.pulsar.handlers.kop.storage.PartitionLog;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -22,7 +22,6 @@ import java.util.function.Consumer;
 import lombok.Getter;
 import lombok.NonNull;
 import org.apache.bookkeeper.common.util.MathUtils;
-import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 
 /**
  * Pending futures of PersistentTopic.
@@ -56,8 +55,8 @@ public class PendingTopicFutures {
         count--;
     }
 
-    public synchronized void addListener(CompletableFuture<Optional<PersistentTopic>> topicFuture,
-                            @NonNull Consumer<Optional<PersistentTopic>> persistentTopicConsumer,
+    public synchronized void addListener(CompletableFuture<PartitionLog> topicFuture,
+                            @NonNull Consumer<PartitionLog> persistentTopicConsumer,
                             @NonNull Consumer<Throwable> exceptionConsumer) {
         if (count == 0) {
             count = 1;
@@ -109,19 +108,19 @@ public class PendingTopicFutures {
 
 class TopicThrowablePair {
     @Getter
-    private final Optional<PersistentTopic> persistentTopicOpt;
+    private final PartitionLog persistentTopicOpt;
     @Getter
     private final Throwable throwable;
 
-    public static TopicThrowablePair withTopic(final Optional<PersistentTopic> persistentTopicOpt) {
+    public static TopicThrowablePair withTopic(final PartitionLog persistentTopicOpt) {
         return new TopicThrowablePair(persistentTopicOpt, null);
     }
 
     public static TopicThrowablePair withThrowable(final Throwable throwable) {
-        return new TopicThrowablePair(Optional.empty(), throwable);
+        return new TopicThrowablePair(null, throwable);
     }
 
-    private TopicThrowablePair(final Optional<PersistentTopic> persistentTopicOpt, final Throwable throwable) {
+    private TopicThrowablePair(final PartitionLog persistentTopicOpt, final Throwable throwable) {
         this.persistentTopicOpt = persistentTopicOpt;
         this.throwable = throwable;
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -42,7 +42,7 @@ public class PartitionLogManager {
 
     private final KafkaServiceConfiguration kafkaConfig;
     private final RequestStats requestStats;
-    private final Map<String, CompletableFuture<PartitionLog>> logMap;
+    private final Map<String, PartitionLog> logMap;
     private final Time time;
     private final ImmutableMap<String, EntryFilterWithClassLoader> entryfilterMap;
 
@@ -69,35 +69,33 @@ public class PartitionLogManager {
         this.recoveryExecutor = recoveryExecutor;
     }
 
-    public CompletableFuture<PartitionLog> getLog(TopicPartition topicPartition, String namespacePrefix) {
+    public PartitionLog getLog(TopicPartition topicPartition, String namespacePrefix) {
         String kopTopic = KopTopic.toString(topicPartition, namespacePrefix);
         String tenant = TopicName.get(kopTopic).getTenant();
         ProducerStateManagerSnapshotBuffer prodPerTenant = producerStateManagerSnapshotBuffer.apply(tenant);
-        CompletableFuture<PartitionLog> res =  logMap.computeIfAbsent(kopTopic, key -> {
-            log.info("init getLog {}", key);
-            CompletableFuture<PartitionLog> result = new PartitionLog(kafkaConfig, requestStats,
+        PartitionLog res =  logMap.computeIfAbsent(kopTopic, key -> {
+            PartitionLog partitionLog = new PartitionLog(kafkaConfig, requestStats,
                     time, topicPartition, key, entryfilterMap,
                     kafkaTopicLookupService,
-                    prodPerTenant)
+                    prodPerTenant);
+
+            CompletableFuture<PartitionLog> initialiseResult = partitionLog
                     .initialise(recoveryExecutor);
 
-            result.whenComplete((___, error) -> {
+            initialiseResult.whenComplete((___, error) -> {
                 if (error != null) {
                     // in case of failure we have to remove the CompletableFuture from the map
                     log.error("Recovery of {} failed", key, error);
-                    logMap.remove(key, result);
+                    logMap.remove(key, partitionLog);
                 }
             });
 
-            return result;
+            return partitionLog;
         });
-        if (res.isCompletedExceptionally()) {
-            logMap.remove(kopTopic, res);
-        }
         return res;
     }
 
-    public CompletableFuture<PartitionLog> removeLog(String topicName) {
+    public PartitionLog removeLog(String topicName) {
         log.info("removePartitionLog {}", topicName);
         return logMap.remove(topicName);
     }
@@ -109,15 +107,12 @@ public class PartitionLogManager {
     public CompletableFuture<Void> takeProducerStateSnapshots() {
         List<CompletableFuture<Void>> handles = new ArrayList<>();
         logMap.values().forEach(log -> {
-            if (log.isDone() && !log.isCompletedExceptionally()) {
-                PartitionLog partitionLog = log.getNow(null);
-                if (partitionLog != null) {
-                    handles.add(partitionLog
-                            .getProducerStateManager()
-                            .takeSnapshot(recoveryExecutor)
-                            .thenApply(___ -> null));
+                if (log.isInitialised()) {
+                    handles.add(log
+                        .getProducerStateManager()
+                        .takeSnapshot(recoveryExecutor)
+                        .thenApply(___ -> null));
                 }
-            }
         });
         return FutureUtil.waitForAll(handles);
     }
@@ -125,12 +120,9 @@ public class PartitionLogManager {
     public CompletableFuture<?> purgeAbortedTxns() {
         List<CompletableFuture<Long>> handles = new ArrayList<>();
         logMap.values().forEach(log -> {
-            if (log.isDone() && !log.isCompletedExceptionally()) {
-                PartitionLog partitionLog = log.getNow(null);
-                if (partitionLog != null) {
-                    handles.add(partitionLog
-                            .purgeAbortedTxns());
-                }
+            if (log.isInitialised()) {
+                handles.add(log
+                        .purgeAbortedTxns());
             }
         });
         return FutureUtil

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -92,6 +92,10 @@ public class PartitionLogManager {
 
             return partitionLog;
         });
+        if (res.isInitialisationFailed()) {
+            log.error("Recovery of {} failed", kopTopic, res);
+            logMap.remove(kopTopic, res);
+        }
         return res;
     }
 

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/PendingTopicFuturesTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/PendingTopicFuturesTest.java
@@ -13,10 +13,12 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
+import static org.mockito.Mockito.mock;
+
+import io.streamnative.pulsar.handlers.kop.storage.PartitionLog;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
@@ -25,9 +27,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
 
 /**
  * Test for PendingTopicFutures.
@@ -61,7 +63,7 @@ public class PendingTopicFuturesTest {
     @Test(timeOut = 10000)
     void testNormalComplete() throws ExecutionException, InterruptedException {
         final PendingTopicFutures pendingTopicFutures = new PendingTopicFutures(null);
-        final CompletableFuture<Optional<PersistentTopic>> topicFuture = new CompletableFuture<>();
+        final CompletableFuture<PartitionLog> topicFuture = new CompletableFuture<>();
         final List<Integer> completedIndexes = new ArrayList<>();
         final List<Integer> changesOfPendingCount = new ArrayList<>();
         int randomNum = ThreadLocalRandom.current().nextInt(0, 9);
@@ -72,7 +74,7 @@ public class PendingTopicFuturesTest {
                     topicFuture, ignored -> completedIndexes.add(index), (ignore) -> {});
             changesOfPendingCount.add(pendingTopicFutures.size());
             if (randomNum == i) {
-                topicFuture.complete(Optional.empty());
+                topicFuture.complete(mock(PartitionLog.class));
             }
         }
 
@@ -94,7 +96,7 @@ public class PendingTopicFuturesTest {
     @Test(timeOut = 10000)
     void testExceptionalComplete() throws ExecutionException, InterruptedException {
         final PendingTopicFutures pendingTopicFutures = new PendingTopicFutures(null);
-        final CompletableFuture<Optional<PersistentTopic>> topicFuture = new CompletableFuture<>();
+        final CompletableFuture<PartitionLog> topicFuture = new CompletableFuture<>();
         final List<String> exceptionMessages = new ArrayList<>();
         final List<Integer> changesOfPendingCount = new ArrayList<>();
 
@@ -128,7 +130,7 @@ public class PendingTopicFuturesTest {
     @Test(timeOut = 10000)
     void testParallelAccess() throws ExecutionException, InterruptedException {
         final PendingTopicFutures pendingTopicFutures = new PendingTopicFutures(null);
-        final CompletableFuture<Optional<PersistentTopic>> topicFuture = new CompletableFuture<>();
+        final CompletableFuture<PartitionLog> topicFuture = new CompletableFuture<>();
         final List<Integer> completedIndexes = new CopyOnWriteArrayList<>();
         int randomNum = ThreadLocalRandom.current().nextInt(0, 9);
 
@@ -142,7 +144,7 @@ public class PendingTopicFuturesTest {
                             topicFuture, ignored -> completedIndexes.add(index), (ignore) -> {
                             });
                     if (randomNum == index) {
-                        topicFuture.complete(Optional.empty());
+                        topicFuture.complete(mock(PartitionLog.class));
                     }
                 }));
             }

--- a/test-listener/src/main/java/io/streamnative/pulsar/handlers/kop/common/test/TimeOutTestListener.java
+++ b/test-listener/src/main/java/io/streamnative/pulsar/handlers/kop/common/test/TimeOutTestListener.java
@@ -22,9 +22,11 @@ import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.Map;
 import javax.management.JMException;
 import javax.management.ObjectName;
+import lombok.extern.slf4j.Slf4j;
 import org.testng.ITestResult;
 import org.testng.TestListenerAdapter;
 import org.testng.internal.thread.ThreadTimeoutException;
@@ -33,13 +35,28 @@ import org.testng.internal.thread.ThreadTimeoutException;
  * TestNG test listener which prints full thread dump into System.err
  * in case a test is failed due to timeout.
  */
+@Slf4j
 public class TimeOutTestListener extends TestListenerAdapter {
+    @Override
+    public void onTestStart(ITestResult tr) {
+        if (tr.getParameters() != null && tr.getParameters().length > 0) {
+            log.info("onTestStart {} {}", tr.getMethod(), Arrays.toString(tr.getParameters()));
+        } else {
+            log.info("onTestStart {}", tr.getMethod());
+        }
+        super.onTestStart(tr);
+    }
 
     @Override
     public void onTestFailure(ITestResult tr) {
+        if (tr.getParameters() != null && tr.getParameters().length > 0) {
+            log.info("onTestFailure {} {}", tr.getMethod(), Arrays.toString(tr.getParameters()));
+        } else {
+            log.info("onTestFailure {}", tr.getMethod());
+        }
         super.onTestFailure(tr);
 
-        if (tr != null && tr.getThrowable() != null
+        if (tr.getThrowable() != null
                 && tr.getThrowable() instanceof ThreadTimeoutException) {
             System.err.println("====> TEST TIMED OUT. PRINTING THREAD DUMP. <====");
             System.err.println();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
@@ -297,7 +297,7 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
 
         pulsar.getAdminClient().topics().createPartitionedTopic(topic, 2);
 
-        @Cleanup final KafkaProducer<String, String> kafkaProducer = newKafkaProducer();
+        final KafkaProducer<String, String> kafkaProducer = newKafkaProducer();
         sendSingleMessages(kafkaProducer, topic, Arrays.asList("a", "b", "c"));
 
         List<String> expectValues = Arrays.asList("a", "b", "c");
@@ -338,6 +338,8 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
         assertEquals(kafkaReceives.stream().sorted().collect(Collectors.toList()), expectValues,
                 "Expected " + expectValues
                         + " but received " + kafkaReceives.stream().sorted().collect(Collectors.toList()));
+
+        kafkaProducer.close();
 
         pulsar.getAdminClient().topics().deletePartitionedTopic(topic);
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaMessageOrderTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaMessageOrderTestBase.java
@@ -122,7 +122,7 @@ public abstract class KafkaMessageOrderTestBase extends KopProtocolHandlerTestBa
             @Cleanup
             KafkaProducer<Integer, String> producer = new KafkaProducer<>(props);
 
-            int totalMsgs = batchSize * 2 + batchSize / 2;
+            int totalMsgs = 10;
             String messageStrPrefix = "Message_Kop_KafkaProducePulsarConsumeOrder_";
 
             List<CompletableFuture<RecordMetadata>> handles = new ArrayList<>();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaMessageOrderTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaMessageOrderTestBase.java
@@ -122,7 +122,7 @@ public abstract class KafkaMessageOrderTestBase extends KopProtocolHandlerTestBa
             @Cleanup
             KafkaProducer<Integer, String> producer = new KafkaProducer<>(props);
 
-            int totalMsgs = 10;
+            int totalMsgs = batchSize * 2 + batchSize / 2;
             String messageStrPrefix = "Message_Kop_KafkaProducePulsarConsumeOrder_";
 
             List<CompletableFuture<RecordMetadata>> handles = new ArrayList<>();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
@@ -418,7 +418,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
     }
 
 
-    @Test(timeOut = 1000 * 20, dataProvider = "basicRecoveryTestAfterTopicUnloadNumTransactions")
+    @Test(timeOut = 1000 * 30, dataProvider = "basicRecoveryTestAfterTopicUnloadNumTransactions")
     public void basicTestWithTopicUnload(int numTransactionsBetweenUnloads) throws Exception {
 
         String topicName = "basicRecoveryTestAfterTopicUnload_" + numTransactionsBetweenUnloads;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
@@ -853,8 +853,9 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
 
         PartitionLog partitionLog = protocolHandler
                 .getReplicaManager()
-                .getPartitionLog(topicPartition, namespacePrefix)
-                .get();
+                .getPartitionLog(topicPartition, namespacePrefix);
+
+        partitionLog.awaitInitialisation().get();
 
         // verify that we have 2 aborted TX in memory
         assertTrue(partitionLog.getProducerStateManager().hasSomeAbortedTransactions());


### PR DESCRIPTION
Motivation:

KafkaMessageOrderTestBase tests still fail sometimes, from the logs it seems that sometimes the "appendRecords" operation is completed in the wrong thread

```
08:13:47.928 [mock-pulsar-bk-OrderedScheduler-1-0:io.streamnative.pulsar.handlers.kop.storage.ReplicaManager$PendingProduceCallback@127] DEBUG io.streamnative.pulsar.handlers.kop.storage.ReplicaManager - Complete handle appendRecords.
08:13:47.933 [mock-pulsar-bk-OrderedScheduler-1-0:io.streamnative.pulsar.handlers.kop.storage.ReplicaManager$PendingProduceCallback@127] DEBUG io.streamnative.pulsar.handlers.kop.storage.ReplicaManager - Complete handle appendRecords.
08:13:47.936 [mock-pulsar-bk-OrderedScheduler-1-0:io.streamnative.pulsar.handlers.kop.storage.ReplicaManager$PendingProduceCallback@127] DEBUG io.streamnative.pulsar.handlers.kop.storage.ReplicaManager - Complete handle appendRecords.
08:13:47.936 [mock-pulsar-bk-OrderedScheduler-1-0:io.streamnative.pulsar.handlers.kop.storage.ReplicaManager$PendingProduceCallback@127] DEBUG io.streamnative.pulsar.handlers.kop.storage.ReplicaManager - Complete handle appendRecords.
08:13:47.936 [mock-pulsar-bk-OrderedScheduler-1-0:io.streamnative.pulsar.handlers.kop.storage.ReplicaManager$PendingProduceCallback@127] DEBUG io.streamnative.pulsar.handlers.kop.storage.ReplicaManager - Complete handle appendRecords.
08:12:56.570 [kafka-tx-recovery-OrderedExecutor-6-0:io.streamnative.pulsar.handlers.kop.storage.ReplicaManager$PendingProduceCallback@127] DEBUG io.streamnative.pulsar.handlers.kop.storage.ReplicaManager - Complete handle appendRecords.
08:13:30.836 [pulsar-ph-kafka-284-2:io.streamnative.pulsar.handlers.kop.storage.ReplicaManager$PendingProduceCallback@127] DEBUG io.streamnative.pulsar.handlers.kop.storage.ReplicaManager - Complete handle appendRecords.
```


Summary of changes:
- Now PartitionLog wraps a PersistentTopic, it graps the reference during initialisation
- PendingTopicFutures now deals with PartitionLog (we can rename the class eventually)
- Remove some bad handling of references to PersistentTopic instances in KafkaTopicManagerSharedState
- Fix caching of Producers in KafkaTopicManagerSharedState

Benefits:
- now PendingTopicFutures serialises the execution of the writes AFTER the full initialisation of the PartitionLog (that is the Kafka wrapper of the  PersistentTopic) and not of the raw Pulsar PersistentTopic
- the code is much more cleaner (we don't have to deal anymore with the case in which the PersistentTopic is empty and with CompletableFutures and that is can be a different PersistentTopic instance than the initial reference when S4K started to work on the topic)


