### PR TITLE
[transactions] Ensure that SNAPSHOTS and PurgeAbortedTX run on the same thread as writes

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -333,12 +333,9 @@ public class ReplicaManager {
             log.debug("Request key {} unblocked {} fetch requests.", key.keyLabel(), completed);
         }
     }
-    public CompletableFuture<Void> takeProducerStateSnapshots() {
-        return logManager.takeProducerStateSnapshots();
-    }
 
-    public CompletableFuture<?> purgeAbortedTxns() {
-        return logManager.purgeAbortedTxns();
+    public CompletableFuture<?> updatePurgeAbortedTxnsOffsets() {
+        return logManager.updatePurgeAbortedTxnsOffsets();
     }
 
 

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EncodePerformanceTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EncodePerformanceTest.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.Random;
+import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecords;
@@ -51,7 +52,8 @@ public class EncodePerformanceTest {
             "test",
             null,
             mock(KafkaTopicLookupService.class),
-            new MemoryProducerStateManagerSnapshotBuffer());
+            new MemoryProducerStateManagerSnapshotBuffer(),
+            mock(OrderedExecutor.class));
 
     public static void main(String[] args) {
         pulsarServiceConfiguration.setEntryFormat("pulsar");

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
@@ -30,6 +30,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicLong;
+import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
@@ -82,7 +83,8 @@ public class EntryFormatterTest {
             "test",
             null,
             mock(KafkaTopicLookupService.class),
-            new MemoryProducerStateManagerSnapshotBuffer());
+            new MemoryProducerStateManagerSnapshotBuffer(),
+            mock(OrderedExecutor.class));
 
     private void init() {
         pulsarServiceConfiguration.setEntryFormat("pulsar");

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogTest.java
@@ -20,6 +20,7 @@ import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.common.record.CompressionType;
@@ -50,7 +51,8 @@ public class PartitionLogTest {
             "test",
             null,
             mock(KafkaTopicLookupService.class),
-            new MemoryProducerStateManagerSnapshotBuffer());
+            new MemoryProducerStateManagerSnapshotBuffer(),
+            mock(OrderedExecutor.class));
 
     @DataProvider(name = "compressionTypes")
     Object[] allCompressionTypes() {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerTest.java
@@ -62,7 +62,9 @@ public class ProducerStateManagerTest extends KopProtocolHandlerTestBase {
     protected void setUp() {
         producerStateManagerSnapshotBuffer = new MemoryProducerStateManagerSnapshotBuffer();
         stateManager = new ProducerStateManager(partition.toString(), null,
-                producerStateManagerSnapshotBuffer);
+                producerStateManagerSnapshotBuffer,
+                conf.getKafkaTxnProducerStateTopicSnapshotIntervalSeconds(),
+                conf.getKafkaTxnPurgeAbortedTxnIntervalSeconds());
     }
 
     @AfterMethod
@@ -212,7 +214,8 @@ public class ProducerStateManagerTest extends KopProtocolHandlerTestBase {
     public void testSequenceNotValidatedForGroupMetadataTopic() {
         TopicPartition partition = new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0);
         stateManager = new ProducerStateManager(partition.toString(), null,
-                producerStateManagerSnapshotBuffer);
+                producerStateManagerSnapshotBuffer, conf.getKafkaTxnProducerStateTopicSnapshotIntervalSeconds(),
+                conf.getKafkaTxnPurgeAbortedTxnIntervalSeconds());
         short epoch = 0;
         append(stateManager, producerId, epoch, 99L, time.milliseconds(),
                 true, PartitionLog.AppendOrigin.Coordinator);


### PR DESCRIPTION
## Motivation

Some tests are flaky because sometime S4K takes corrupted snapshots because the "takeSnapshot" operation is executed on a different thread.


## Modifications
- Take snapshots only in the same thread that updates the "ProducerState" (the ML write thread)
- Purge Aborted TXs in the same thread that updates the "ProducerState" (the ML write thread)
- Add utility methods to force those operations from tests (this adds much boilerplate)
- Fix recovery from an "invalid snapshot", when we recovery from a snapshot taken in the past we must discard all the history and ignore the snapshot, we will recover the state from the topic (this is still not perfect, as there are edge cases not yet covered)