### PR TITLE
[tests] Unflaky more transactions tests

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/scala/Either.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/scala/Either.java
@@ -16,6 +16,7 @@ package io.streamnative.pulsar.handlers.kop.scala;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import lombok.Getter;
+import lombok.ToString;
 
 /**
  * A simple Java migration of <a href="https://www.scala-lang.org/api/2.13.6/scala/util/Either.html">Scala Either</a>.
@@ -45,6 +46,7 @@ import lombok.Getter;
  * @param <W> the type of the 2nd possible value (the right side)
  */
 @Getter
+@ToString
 public class Either<V, W> {
 
     private final V left;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
@@ -356,14 +356,15 @@ public class ProducerStateManager {
         }
     }
 
-    public void handleMissingDataBeforeRecovery(long minOffset) {
+    public void handleMissingDataBeforeRecovery(long minOffset, long snapshotOffset) {
         if (mapEndOffset == -1) {
             // empty topic
             return;
         }
-        // topic has been fully trimmed
-        if (minOffset < 0) {
-            log.info("{} handleMissingDataBeforeRecovery mapEndOffset {} minOffset {} RESETTING STATE",
+        // topic has been trimmed
+        if (snapshotOffset < minOffset) {
+            log.info("{} handleMissingDataBeforeRecovery mapEndOffset {} snapshotOffset "
+                            + "{} minOffset {} RESETTING STATE",
                     topicPartition,
                     mapEndOffset, minOffset);
             // topic was not empty (mapEndOffset has some value)

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionWithOAuthBearerAuthTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionWithOAuthBearerAuthTest.java
@@ -44,13 +44,10 @@ public class TransactionWithOAuthBearerAuthTest extends TransactionTest {
         adminCredentialPath = HydraOAuthUtils.createOAuthClient(ADMIN_USER, ADMIN_SECRET);
 
         super.resetConfig();
-        conf.setDefaultNumberOfNamespaceBundles(4);
-        conf.setKafkaMetadataNamespace("__kafka");
-        conf.setOffsetsTopicNumPartitions(10);
-        conf.setKafkaTxnLogTopicNumPartitions(10);
-        conf.setKafkaTxnProducerStateTopicNumPartitions(10);
-        conf.setKafkaTransactionCoordinatorEnabled(true);
-        conf.setBrokerDeduplicationEnabled(true);
+        setupTransactions();
+
+
+
         conf.setAuthenticationEnabled(true);
         conf.setAuthorizationEnabled(true);
         conf.setAuthorizationProvider(SaslOAuthKopHandlersTest.OAuthMockAuthorizationProvider.class.getName());


### PR DESCRIPTION
Changes:
- Many transactions tests still reused the same "transactionalId", that messed up the whole test suite
- Disabled automatic snapshot and purgeTx (we will have to follow up adding specific tests for those automatic tasks)
- Added many assertions to testPurgeAbortedTx in order to verify that everything is running as expected
- Consolidated trimConsumedLedgers by temporary disabling "deduplication" (deduplication adds a Subscriptiong pulsar-dedup that makes trimming and also topic truncation unreliable)