### PR TITLE
[transactions]  Add more transactions tests and fix period snapshots and purgeTx period handling

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AbstractPulsarClient.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AbstractPulsarClient.java
@@ -15,12 +15,11 @@ package io.streamnative.pulsar.handlers.kop;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-import java.io.Closeable;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -33,7 +32,7 @@ import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
  */
 @Slf4j
 @Getter
-public abstract class AbstractPulsarClient implements Closeable {
+public abstract class AbstractPulsarClient {
 
     private final PulsarClientImpl pulsarClient;
 
@@ -41,7 +40,6 @@ public abstract class AbstractPulsarClient implements Closeable {
         this.pulsarClient = pulsarClient;
     }
 
-    @Override
     public void close() {
         try {
             pulsarClient.close();
@@ -50,13 +48,8 @@ public abstract class AbstractPulsarClient implements Closeable {
         }
     }
 
-    protected static PulsarClientImpl createPulsarClient(final PulsarService pulsarService) {
-        try {
-            return (PulsarClientImpl) pulsarService.getClient();
-        } catch (PulsarServerException e) {
-            log.error("Failed to create PulsarClient", e);
-            throw new IllegalStateException(e);
-        }
+    public CompletableFuture<?> closeAsync() {
+        return pulsarClient.closeAsync();
     }
 
     /**

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -1133,6 +1133,7 @@ public class PartitionLog {
 
     }
 
+    @VisibleForTesting
     public CompletableFuture<?> takeProducerSnapshot() {
         return initFuture.thenCompose((___)  -> {
             // snapshot can be taken only on the same thread that is used for writes
@@ -1144,6 +1145,7 @@ public class PartitionLog {
         });
     }
 
+    @VisibleForTesting
     public CompletableFuture<Long> forcePurgeAbortTx() {
         return initFuture.thenCompose((___)  -> {
             // purge can be taken only on the same thread that is used for writes

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
@@ -121,6 +121,7 @@ public class ProducerStateManager {
         return result;
     }
 
+    @VisibleForTesting
     public CompletableFuture<ProducerStateManagerSnapshot> takeSnapshot(Executor executor) {
         CompletableFuture<ProducerStateManagerSnapshot> result = new CompletableFuture<>();
         executor.execute(new SafeRunnable() {
@@ -163,7 +164,7 @@ public class ProducerStateManager {
         }
         long now = System.currentTimeMillis();
         long deltaFromLast = (now - lastPurgeAbortedTxnTime) / 1000;
-        if (deltaFromLast / 1000 <= kafkaTxnPurgeAbortedTxnIntervalSeconds) {
+        if (deltaFromLast > kafkaTxnPurgeAbortedTxnIntervalSeconds) {
             return 0;
         }
         lastPurgeAbortedTxnTime = now;
@@ -181,7 +182,11 @@ public class ProducerStateManager {
         }
         long now = System.currentTimeMillis();
         long deltaFromLast = (now - lastSnapshotTime) / 1000;
-        if (deltaFromLast / 1000 <= kafkaTxnPurgeAbortedTxnIntervalSeconds) {
+        if (log.isDebugEnabled()) {
+            log.debug("maybeTakeSnapshot deltaFromLast {} vs kafkaTxnProducerStateTopicSnapshotIntervalSeconds {} ",
+                    deltaFromLast, kafkaTxnProducerStateTopicSnapshotIntervalSeconds);
+        }
+        if (deltaFromLast > kafkaTxnProducerStateTopicSnapshotIntervalSeconds) {
             return;
         }
         lastSnapshotTime = now;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
@@ -13,6 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
+import static org.apache.kafka.clients.CommonClientConfigs.CLIENT_ID_CONFIG;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.testng.Assert.assertEquals;
@@ -1183,6 +1184,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
             // very long time-out
             producerProps.put(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, 600 * 1000);
         }
+        producerProps.put(CLIENT_ID_CONFIG, "dummy_client_" + UUID.randomUUID());
         addCustomizeProps(producerProps);
 
         return new KafkaProducer<>(producerProps);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
@@ -1419,7 +1419,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         }
     }
 
-    @Test(timeOut = 20000)
+    @Test(timeOut = 20000, enabled = false)
     public void testAbortedTxEventuallyPurged() throws Exception {
         KafkaProtocolHandler protocolHandler = (KafkaProtocolHandler)
                 pulsar.getProtocolHandlers().protocol("kafka");

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
@@ -18,6 +18,8 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
@@ -29,6 +31,8 @@ import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionSt
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionStateManager;
 import io.streamnative.pulsar.handlers.kop.scala.Either;
 import io.streamnative.pulsar.handlers.kop.storage.PartitionLog;
+import io.streamnative.pulsar.handlers.kop.storage.ProducerStateManagerSnapshot;
+import io.streamnative.pulsar.handlers.kop.storage.TxnMetadata;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -41,6 +45,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -1347,6 +1352,146 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
 
         producer1.close();
         producer2.close();
+    }
+
+    @Test(timeOut = 20000)
+    public void testSnapshotEventuallyTaken() throws Exception {
+        KafkaProtocolHandler protocolHandler = (KafkaProtocolHandler)
+                pulsar.getProtocolHandlers().protocol("kafka");
+        int kafkaTxnPurgeAbortedTxnIntervalSeconds = conf.getKafkaTxnPurgeAbortedTxnIntervalSeconds();
+        conf.setKafkaTxnProducerStateTopicSnapshotIntervalSeconds(2);
+        try {
+            String topicName = "testSnapshotEventuallyTaken";
+            TopicName topicName1 = TopicName.get(topicName);
+            String fullTopicName = topicName1.getPartition(0).toString();
+            String transactionalId = "myProducer_" + UUID.randomUUID();
+
+            @Cleanup
+            AdminClient kafkaAdmin = AdminClient.create(newKafkaAdminClientProperties());
+            kafkaAdmin.createTopics(Arrays.asList(new NewTopic(topicName, 1, (short) 1)));
+
+            // no snapshot initially
+            assertNull(protocolHandler.getTransactionCoordinator(tenant)
+                    .getProducerStateManagerSnapshotBuffer()
+                    .readLatestSnapshot(fullTopicName)
+                    .get());
+
+            final KafkaProducer<Integer, String> producer1 = buildTransactionProducer(transactionalId);
+
+            producer1.initTransactions();
+            producer1.beginTransaction();
+            producer1.send(new ProducerRecord<>(topicName, "test")); // OFFSET 0
+            producer1.commitTransaction(); // OFFSET 1
+
+            producer1.beginTransaction();
+            producer1.send(new ProducerRecord<>(topicName, "test")); // OFFSET 2 - first offset
+            producer1.send(new ProducerRecord<>(topicName, "test")).get(); // OFFSET 3
+
+            Thread.sleep(conf.getKafkaTxnProducerStateTopicSnapshotIntervalSeconds() * 1000 + 5);
+
+            // sending a message triggers the creation of the snapshot
+            producer1.send(new ProducerRecord<>(topicName, "test")).get(); // OFFSET 4
+
+            // snapshot is written and sent to Pulsar async and also the ProducerStateManagerSnapshotBuffer
+            // reads it asynchronously
+
+            Awaitility
+                    .await()
+                    .pollDelay(5, TimeUnit.SECONDS)
+                    .untilAsserted(() -> {
+                ProducerStateManagerSnapshot snapshot = protocolHandler.getTransactionCoordinator(tenant)
+                        .getProducerStateManagerSnapshotBuffer()
+                        .readLatestSnapshot(fullTopicName)
+                        .get();
+
+                assertNotNull(snapshot);
+                assertEquals(4, snapshot.getOffset());
+                assertEquals(1, snapshot.getProducers().size());
+                assertEquals(1, snapshot.getOngoingTxns().size());
+                assertNotNull(snapshot.getTopicUUID());
+                TxnMetadata txnMetadata = snapshot.getOngoingTxns().values().iterator().next();
+                assertEquals(txnMetadata.firstOffset(), 2);
+            });
+
+            producer1.close();
+        } finally {
+            conf.setKafkaTxnProducerStateTopicSnapshotIntervalSeconds(kafkaTxnPurgeAbortedTxnIntervalSeconds);
+        }
+    }
+
+    @Test(timeOut = 20000)
+    public void testAbortedTxEventuallyPurged() throws Exception {
+        KafkaProtocolHandler protocolHandler = (KafkaProtocolHandler)
+                pulsar.getProtocolHandlers().protocol("kafka");
+        int kafkaTxnPurgeAbortedTxnIntervalSeconds = conf.getKafkaTxnPurgeAbortedTxnIntervalSeconds();
+        conf.setKafkaTxnPurgeAbortedTxnIntervalSeconds(2);
+        try {
+            String topicName = "testAbortedTxEventuallyPurged";
+            TopicName topicName1 = TopicName.get(topicName);
+            String fullTopicName = topicName1.getPartition(0).toString();
+            String transactionalId = "myProducer_" + UUID.randomUUID();
+            TopicPartition topicPartition = new TopicPartition(topicName, 0);
+            String namespacePrefix = topicName1.getNamespace();
+
+            @Cleanup
+            AdminClient kafkaAdmin = AdminClient.create(newKafkaAdminClientProperties());
+            kafkaAdmin.createTopics(Arrays.asList(new NewTopic(topicName, 1, (short) 1)));
+
+            final KafkaProducer<Integer, String> producer1 = buildTransactionProducer(transactionalId);
+
+            producer1.initTransactions();
+            producer1.beginTransaction();
+            producer1.send(new ProducerRecord<>(topicName, "test")).get(); // OFFSET 0
+            producer1.send(new ProducerRecord<>(topicName, "test")).get(); // OFFSET 1
+            producer1.abortTransaction(); // OFFSET 2
+
+            waitForTransactionsToBeInStableState(transactionalId);
+
+            PartitionLog partitionLog = protocolHandler
+                    .getReplicaManager()
+                    .getPartitionLog(topicPartition, namespacePrefix);
+            partitionLog.awaitInitialisation().get();
+
+            List<FetchResponse.AbortedTransaction> abortedIndexList =
+                    partitionLog.getProducerStateManager().getAbortedIndexList(Long.MIN_VALUE);
+            assertEquals(1, abortedIndexList.size());
+
+            takeSnapshot(topicName);
+
+
+            assertEquals(0, partitionLog.fetchOldestAvailableIndexFromTopic().get().longValue());
+
+            // unload and reload in order to have at least 2 ledgers in the
+            // topic, this way we can drop the head ledger
+            admin.namespaces().unload(namespacePrefix);
+            admin.lookups().lookupTopic(fullTopicName);
+
+            trimConsumedLedgers(fullTopicName);
+
+            assertEquals(2, partitionLog.fetchOldestAvailableIndexFromTopic().get().longValue());
+
+            abortedIndexList =
+                    partitionLog.getProducerStateManager().getAbortedIndexList(Long.MIN_VALUE);
+            assertEquals(1, abortedIndexList.size());
+
+
+            partitionLog.updatePurgeAbortedTxnsOffset().get();
+
+            Thread.sleep(conf.getKafkaTxnPurgeAbortedTxnIntervalSeconds() * 1000
+                    + 5);
+
+            producer1.beginTransaction();
+            // sending a message triggers the procedure
+            producer1.send(new ProducerRecord<>(topicName, "test")).get();
+
+            abortedIndexList =
+                    partitionLog.getProducerStateManager().getAbortedIndexList(Long.MIN_VALUE);
+            assertEquals(0, abortedIndexList.size());
+
+            producer1.close();
+        } finally {
+            conf.setKafkaTxnPurgeAbortedTxnIntervalSeconds(kafkaTxnPurgeAbortedTxnIntervalSeconds);
+        }
     }
 
     /**


### PR DESCRIPTION
Changes:
- Fix automatic execution of takeSnapshot() and purgeAbortedTx() and add tests
- Do no use the same client.id in order to not see JMX errors
- Do not block the broker forever while shutting down

