### PR TITLE
[tests] Add tests about automatic purge of aborted TXs

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -48,6 +48,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import lombok.AllArgsConstructor;
@@ -152,6 +153,8 @@ public class PartitionLog {
 
     private volatile EntryFormatter entryFormatter;
 
+    private volatile AtomicBoolean unloaded = new AtomicBoolean();
+
     public PartitionLog(KafkaServiceConfiguration kafkaConfig,
                         RequestStats requestStats,
                         Time time,
@@ -205,6 +208,10 @@ public class PartitionLog {
 
     public boolean isInitialisationFailed() {
         return initFuture.isDone() && initFuture.isCompletedExceptionally();
+    }
+
+    public void markAsUnloaded() {
+        unloaded.set(true);
     }
 
     private CompletableFuture<Void> loadTopicProperties() {
@@ -1073,12 +1080,20 @@ public class PartitionLog {
             // nothing to do
             return CompletableFuture.completedFuture(null);
         }
+        if (unloaded.get()) {
+            // nothing to do
+            return CompletableFuture.completedFuture(null);
+        }
         return fetchOldestAvailableIndexFromTopic()
                 .thenAccept(offset ->
                     producerStateManager.updateAbortedTxnsPurgeOffset(offset));
 
     }
     public CompletableFuture<Long> fetchOldestAvailableIndexFromTopic() {
+        if (unloaded.get()) {
+            return FutureUtil.failedFuture(new NotLeaderOrFollowerException());
+        }
+
         final CompletableFuture<Long> future = new CompletableFuture<>();
 
         // The future that is returned by getTopicConsumerManager is always completed normally
@@ -1094,8 +1109,9 @@ public class PartitionLog {
             }
         });
 
-        ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) tcm.getManagedLedger();
-        if (managedLedger.getNumberOfEntries() == 0) {
+        ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) persistentTopic.getManagedLedger();
+        long numberOfEntries = managedLedger.getNumberOfEntries();
+        if (numberOfEntries == 0) {
             long currentOffset = MessageMetadataUtils.getCurrentOffset(managedLedger);
             log.info("First offset for topic {} is {} as the topic is empty (numberOfEntries=0)",
                     fullPartitionName, currentOffset);
@@ -1103,6 +1119,7 @@ public class PartitionLog {
 
             return future;
         }
+        log.info("{} numberOfEntries={}", fullPartitionName, numberOfEntries);
         // this is a DUMMY entry with -1
         PositionImpl firstPosition = managedLedger.getFirstPosition();
         // look for the first entry with data
@@ -1365,4 +1382,7 @@ public class PartitionLog {
         );
     }
 
+    public boolean isUnloaded() {
+        return unloaded.get();
+    }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -86,6 +86,7 @@ public class PartitionLogManager {
                 if (error != null) {
                     // in case of failure we have to remove the CompletableFuture from the map
                     log.error("Recovery of {} failed", key, error);
+                    partitionLog.markAsUnloaded();
                     logMap.remove(key, partitionLog);
                 }
             });
@@ -94,6 +95,7 @@ public class PartitionLogManager {
         });
         if (res.isInitialisationFailed()) {
             log.error("Recovery of {} failed", kopTopic, res);
+            res.markAsUnloaded();
             logMap.remove(kopTopic, res);
         }
         return res;
@@ -101,7 +103,11 @@ public class PartitionLogManager {
 
     public PartitionLog removeLog(String topicName) {
         log.info("removePartitionLog {}", topicName);
-        return logMap.remove(topicName);
+        PartitionLog exists =  logMap.remove(topicName);
+        if (exists != null) {
+            exists.markAsUnloaded();
+        }
+        return exists;
     }
 
     public int size() {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
@@ -150,7 +150,7 @@ public class ProducerStateManager {
 
     void updateAbortedTxnsPurgeOffset(long abortedTxnsPurgeOffset) {
         if (log.isDebugEnabled()) {
-            log.debug("{} updateAbortedTxnsPurgeOffset {}", topicPartition, abortedTxnsPurgeOffset);
+            log.debug("{} updateAbortedTxnsPurgeOffset offset={}", topicPartition, abortedTxnsPurgeOffset);
         }
         if (abortedTxnsPurgeOffset < 0) {
             return;
@@ -164,6 +164,10 @@ public class ProducerStateManager {
         }
         long now = System.currentTimeMillis();
         long deltaFromLast = (now - lastPurgeAbortedTxnTime) / 1000;
+        if (log.isDebugEnabled()) {
+            log.debug("maybePurgeAbortedTx deltaFromLast {} vs kafkaTxnPurgeAbortedTxnIntervalSeconds {} ",
+                    deltaFromLast, kafkaTxnPurgeAbortedTxnIntervalSeconds);
+        }
         if (deltaFromLast > kafkaTxnPurgeAbortedTxnIntervalSeconds) {
             return 0;
         }
@@ -338,6 +342,10 @@ public class ProducerStateManager {
                 if (toRemove) {
                     log.info("Transaction {} can be removed (lastOffset < {})", tx, tx.lastOffset(), offset);
                     count.incrementAndGet();
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.info("Transaction {} cannot be removed (lastOffset >= {})", tx, tx.lastOffset(), offset);
+                    }
                 }
                 return toRemove;
             });

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
@@ -1419,7 +1419,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         }
     }
 
-    @Test(timeOut = 20000, enabled = false)
+    @Test(timeOut = 30000)
     public void testAbortedTxEventuallyPurged() throws Exception {
         KafkaProtocolHandler protocolHandler = (KafkaProtocolHandler)
                 pulsar.getProtocolHandlers().protocol("kafka");
@@ -1445,6 +1445,11 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
             producer1.send(new ProducerRecord<>(topicName, "test")).get(); // OFFSET 1
             producer1.abortTransaction(); // OFFSET 2
 
+            producer1.beginTransaction();
+            producer1.send(new ProducerRecord<>(topicName, "test")).get(); // OFFSET 3
+            producer1.send(new ProducerRecord<>(topicName, "test")).get(); // OFFSET 4
+            producer1.abortTransaction(); // OFFSET 5
+
             waitForTransactionsToBeInStableState(transactionalId);
 
             PartitionLog partitionLog = protocolHandler
@@ -1454,7 +1459,10 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
 
             List<FetchResponse.AbortedTransaction> abortedIndexList =
                     partitionLog.getProducerStateManager().getAbortedIndexList(Long.MIN_VALUE);
-            assertEquals(1, abortedIndexList.size());
+            assertEquals(2, abortedIndexList.size());
+            assertEquals(2, abortedIndexList.size());
+            assertEquals(0, abortedIndexList.get(0).firstOffset);
+            assertEquals(3, abortedIndexList.get(1).firstOffset);
 
             takeSnapshot(topicName);
 
@@ -1466,19 +1474,29 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
             admin.namespaces().unload(namespacePrefix);
             admin.lookups().lookupTopic(fullTopicName);
 
+            assertTrue(partitionLog.isUnloaded());
+
             trimConsumedLedgers(fullTopicName);
 
-            assertEquals(2, partitionLog.fetchOldestAvailableIndexFromTopic().get().longValue());
+            partitionLog = protocolHandler
+                    .getReplicaManager()
+                    .getPartitionLog(topicPartition, namespacePrefix);
+            partitionLog.awaitInitialisation().get();
+            assertEquals(5, partitionLog.fetchOldestAvailableIndexFromTopic().get().longValue());
 
             abortedIndexList =
                     partitionLog.getProducerStateManager().getAbortedIndexList(Long.MIN_VALUE);
-            assertEquals(1, abortedIndexList.size());
+            assertEquals(2, abortedIndexList.size());
+            assertEquals(0, abortedIndexList.get(0).firstOffset);
+            assertEquals(3, abortedIndexList.get(1).firstOffset);
 
-
+            // force reading the minimum valid offset
+            // the timer is not started by the PH because
+            // we don't want it to make noise in the other tests
             partitionLog.updatePurgeAbortedTxnsOffset().get();
 
-            Thread.sleep(conf.getKafkaTxnPurgeAbortedTxnIntervalSeconds() * 1000
-                    + 5);
+            // wait for some time
+            Thread.sleep(conf.getKafkaTxnPurgeAbortedTxnIntervalSeconds() * 1000 + 5);
 
             producer1.beginTransaction();
             // sending a message triggers the procedure
@@ -1486,9 +1504,13 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
 
             abortedIndexList =
                     partitionLog.getProducerStateManager().getAbortedIndexList(Long.MIN_VALUE);
-            assertEquals(0, abortedIndexList.size());
+            assertEquals(1, abortedIndexList.size());
+            // the second TX cannot be purged because the lastOffset is 5, that is the boundary of the
+            // trimmed portion of the topic
+            assertEquals(3, abortedIndexList.get(0).firstOffset);
 
             producer1.close();
+
         } finally {
             conf.setKafkaTxnPurgeAbortedTxnIntervalSeconds(kafkaTxnPurgeAbortedTxnIntervalSeconds);
         }


### PR DESCRIPTION
Modifications:
- enable testAbortedTxEventuallyPurged
- add mechanisms to prevent an "unloaded" PartitionLog to serve some methods that are not covered by the low level fencing mechanism of ManagedLedger