### PR TITLE
Add multi-tenant support for OAuth authentication (#1728)

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerSaslServer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerSaslServer.java
@@ -111,6 +111,9 @@ public class KopOAuthBearerSaslServer implements SaslServer {
             return tokenForNegotiatedProperty.authDataSource();
         }
         if (USER_NAME_PROP.equals(propName)) {
+            if (tokenForNegotiatedProperty.tenant() != null) {
+                return tokenForNegotiatedProperty.tenant();
+            }
             return defaultKafkaMetadataTenant;
         }
         return NEGOTIATED_PROPERTY_KEY_TOKEN.equals(propName) ? tokenForNegotiatedProperty : null;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerToken.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerToken.java
@@ -27,5 +27,10 @@ public interface KopOAuthBearerToken extends OAuthBearerToken {
      * Pass the auth data to oauth server.
      */
     AuthenticationDataSource authDataSource();
+
+    /**
+     * Pass the tenant to oauth server if credentials set.
+     */
+    String tenant();
 }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerUnsecuredJws.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerUnsecuredJws.java
@@ -28,6 +28,8 @@ import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 public class KopOAuthBearerUnsecuredJws extends OAuthBearerUnsecuredJws implements KopOAuthBearerToken {
 
     private final AuthenticationDataCommand authData;
+
+    private final String tenant;
     /**
      * Constructor with the given principal and scope claim names.
      *
@@ -41,14 +43,21 @@ public class KopOAuthBearerUnsecuredJws extends OAuthBearerUnsecuredJws implemen
      *                                          after decoding; or the mandatory '{@code alg}' header value is
      *                                          not "{@code none}")
      */
-    public KopOAuthBearerUnsecuredJws(String compactSerialization, String principalClaimName, String scopeClaimName)
+    public KopOAuthBearerUnsecuredJws(String compactSerialization, String tenant, String principalClaimName,
+                                      String scopeClaimName)
             throws OAuthBearerIllegalTokenException {
         super(compactSerialization, principalClaimName, scopeClaimName);
         this.authData = new AuthenticationDataCommand(compactSerialization);
+        this.tenant = tenant;
     }
 
     @Override
     public AuthenticationDataSource authDataSource() {
         return authData;
+    }
+
+    @Override
+    public String tenant() {
+        return tenant;
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerUnsecuredValidatorCallbackHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerUnsecuredValidatorCallbackHandler.java
@@ -22,6 +22,7 @@ import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.AppConfigurationEntry;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
 import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerConfigException;
@@ -115,7 +116,11 @@ public class KopOAuthBearerUnsecuredValidatorCallbackHandler implements Authenti
         String scopeClaimName = scopeClaimName();
         List<String> requiredScope = requiredScope();
         int allowableClockSkewMs = allowableClockSkewMs();
-        KopOAuthBearerUnsecuredJws unsecuredJwt = new KopOAuthBearerUnsecuredJws(tokenValue, principalClaimName,
+        // Extract real token.
+        Pair<String, String> tokenAndTenant = OAuthTokenDecoder.decode(tokenValue);
+        final String token = tokenAndTenant.getLeft();
+        final String tenant = tokenAndTenant.getRight();
+        KopOAuthBearerUnsecuredJws unsecuredJwt = new KopOAuthBearerUnsecuredJws(token, tenant, principalClaimName,
                 scopeClaimName);
         long now = time.milliseconds();
         OAuthBearerValidationUtils

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/OAuthTokenDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/OAuthTokenDecoder.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.security.oauth;
+
+import lombok.NonNull;
+import org.apache.commons.lang3.tuple.Pair;
+
+public class OAuthTokenDecoder {
+
+    protected static final String DELIMITER = "__with_tenant_";
+
+    /**
+     * Decode the raw token to token and tenant.
+     *
+     * @param rawToken Raw token, it contains token and tenant. Format: Tenant + "__with_tenant_" + Token.
+     * @return Token and tenant pair. Left is token, right is tenant.
+     */
+    public static Pair<String, String> decode(@NonNull String rawToken) {
+        final String token;
+        final String tenant;
+        // Extract real token.
+        int idx = rawToken.indexOf(DELIMITER);
+        if (idx != -1) {
+            token = rawToken.substring(idx + DELIMITER.length());
+            tenant = rawToken.substring(0, idx);
+        } else {
+            token = rawToken;
+            tenant = null;
+        }
+        return Pair.of(token, tenant);
+    }
+}

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/security/oauth/OAuthTokenDecoderTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/security/oauth/OAuthTokenDecoderTest.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.security.oauth;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.testng.annotations.Test;
+
+/**
+ * Test {@link OAuthTokenDecoder}.
+ */
+public class OAuthTokenDecoderTest {
+
+    @Test
+    public void testDecode() {
+        Pair<String, String> tokenAndTenant = OAuthTokenDecoder.decode("my-token");
+        assertEquals(tokenAndTenant.getLeft(), "my-token");
+        assertNull(tokenAndTenant.getRight());
+        tokenAndTenant = OAuthTokenDecoder.decode("my-tenant" + OAuthTokenDecoder.DELIMITER + "my-token");
+        assertEquals(tokenAndTenant.getLeft(), "my-token");
+        assertEquals(tokenAndTenant.getRight(), "my-tenant");
+    }
+}

--- a/oauth-client/pom.xml
+++ b/oauth-client/pom.xml
@@ -53,6 +53,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>test-listener</artifactId>
       <scope>test</scope>

--- a/oauth-client/pom.xml
+++ b/oauth-client/pom.xml
@@ -63,6 +63,13 @@
       <artifactId>test-listener</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/oauth-client/src/main/java/com/datastax/oss/kafka/oauth/ClientCredentialsFlow.java
+++ b/oauth-client/src/main/java/com/datastax/oss/kafka/oauth/ClientCredentialsFlow.java
@@ -54,12 +54,6 @@ public class ClientCredentialsFlow implements Closeable {
         this.clientConfig = clientConfig;
     }
 
-    @VisibleForTesting
-    protected ClientCredentialsFlow(ClientConfig clientConfig, AsyncHttpClient httpClient) {
-        this.clientConfig = clientConfig;
-        this.httpClient = httpClient;
-    }
-
     public OAuthBearerTokenImpl authenticate() throws IOException {
         final String tokenEndPoint = findAuthorizationServer().getTokenEndPoint();
         final ClientInfo clientInfo = loadPrivateKey();
@@ -77,7 +71,6 @@ public class ClientCredentialsFlow implements Closeable {
                 o.write(body.getBytes(StandardCharsets.UTF_8));
             }
             try (InputStream in = con.getInputStream()) {
-                return TOKEN_RESULT_READER.readValue(in);
                 OAuthBearerTokenImpl token = TOKEN_RESULT_READER.readValue(in);
                 String tenant = clientInfo.getTenant();
                 // Add tenant for multi-tenant.

--- a/oauth-client/src/main/java/com/datastax/oss/kafka/oauth/OAuthBearerTokenImpl.java
+++ b/oauth-client/src/main/java/com/datastax/oss/kafka/oauth/OAuthBearerTokenImpl.java
@@ -24,6 +24,8 @@ import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class OAuthBearerTokenImpl implements OAuthBearerToken {
 
+    protected static final String DELIMITER = "__with_tenant_";
+
     @JsonProperty("access_token")
     private String accessToken;
 
@@ -38,6 +40,10 @@ public class OAuthBearerTokenImpl implements OAuthBearerToken {
     @Override
     public String value() {
         return accessToken;
+    }
+
+    public void setTenant(String tenant) {
+        this.accessToken = tenant + DELIMITER + accessToken;
     }
 
     @Override

--- a/oauth-client/src/test/java/com/datastax/oss/kafka/oauth/ClientCredentialsFlowTest.java
+++ b/oauth-client/src/test/java/com/datastax/oss/kafka/oauth/ClientCredentialsFlowTest.java
@@ -13,7 +13,9 @@
  */
 package com.datastax.oss.kafka.oauth;
 
-import static org.mockito.ArgumentMatchers.anyString;
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -21,15 +23,14 @@ import static org.mockito.Mockito.spy;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Objects;
-import java.util.concurrent.ExecutionException;
-import org.asynchttpclient.AsyncHttpClient;
-import org.asynchttpclient.BoundRequestBuilder;
-import org.asynchttpclient.ListenableFuture;
-import org.asynchttpclient.Response;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class ClientCredentialsFlowTest {
+
 
     @Test(enabled = false)
     public void testFindAuthorizationServer() throws IOException {
@@ -55,37 +56,38 @@ public class ClientCredentialsFlowTest {
     }
 
     @Test
-    public void testTenantToken() throws ExecutionException, InterruptedException, IOException {
-        AsyncHttpClient mockHttpClient = mock(AsyncHttpClient.class);
-        final ClientCredentialsFlow flow = spy(new ClientCredentialsFlow(ClientConfigHelper.create(
-                "http://localhost:4444",
-                Objects.requireNonNull(
-                        getClass().getClassLoader().getResource("private_key.json")).toString()
-        ), mockHttpClient));
+    public void testTenantToken() throws Exception {
+        WireMockServer mockOauthServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        try {
+            mockOauthServer.start();
 
-        ClientCredentialsFlow.Metadata mockMetadata = mock(ClientCredentialsFlow.Metadata.class);
-        doReturn("mockTokenEndPoint").when(mockMetadata).getTokenEndPoint();
+            final ClientCredentialsFlow flow = spy(new ClientCredentialsFlow(ClientConfigHelper.create(
+                    mockOauthServer.url("/"),
+                    Objects.requireNonNull(
+                            getClass().getClassLoader().getResource("private_key.json")).toString()
+            )));
 
-        doReturn(mockMetadata).when(flow).findAuthorizationServer();
+            ClientCredentialsFlow.Metadata mockMetadata = mock(ClientCredentialsFlow.Metadata.class);
+            doReturn(mockOauthServer.url("/mockTokenEndPoint")).when(mockMetadata).getTokenEndPoint();
 
-        BoundRequestBuilder mockBuilder = mock(BoundRequestBuilder.class);
-        ListenableFuture<Response> mockFuture = mock(ListenableFuture.class);
-        Response mockResponse = mock(Response.class);
-        doReturn(200).when(mockResponse).getStatusCode();
-        String responseString = "{\n"
-                + "    \"access_token\":\"my-token\",\n"
-                + "    \"expires_in\":42,\n"
-                + "    \"scope\":\"test\"\n"
-                + "}";
-        doReturn(responseString.getBytes()).when(mockResponse).getResponseBodyAsBytes();
-        doReturn(mockResponse).when(mockFuture).get();
-        doReturn(mockFuture).when(mockBuilder).execute();
-        doReturn(mockBuilder).when(mockHttpClient).preparePost(anyString());
-        doReturn(mockBuilder).when(mockBuilder).setHeader(anyString(), anyString());
-        doReturn(mockBuilder).when(mockBuilder).setBody(anyString());
+            doReturn(mockMetadata).when(flow).findAuthorizationServer();
 
-        OAuthBearerTokenImpl token = flow.authenticate();
-        Assert.assertEquals(token.value(), "my-tenant" + OAuthBearerTokenImpl.DELIMITER + "my-token");
-        Assert.assertEquals(token.scope(), Collections.singleton("test"));
+            String responseString = "{\n"
+                    + "    \"access_token\":\"my-token\",\n"
+                    + "    \"expires_in\":42,\n"
+                    + "    \"scope\":\"test\"\n"
+                    + "}";
+            configureFor("localhost", mockOauthServer.port());
+            stubFor(WireMock.post(urlPathEqualTo("/mockTokenEndPoint"))
+                    .willReturn(WireMock.ok(responseString))
+            );
+
+            OAuthBearerTokenImpl token = flow.authenticate();
+            Assert.assertEquals(token.value(), "my-tenant" + OAuthBearerTokenImpl.DELIMITER + "my-token");
+            Assert.assertEquals(token.scope(), Collections.singleton("test"));
+        } finally {
+            mockOauthServer.shutdown();
+        }
+
     }
 }

--- a/oauth-client/src/test/java/com/datastax/oss/kafka/oauth/ClientCredentialsFlowTest.java
+++ b/oauth-client/src/test/java/com/datastax/oss/kafka/oauth/ClientCredentialsFlowTest.java
@@ -13,8 +13,19 @@
  */
 package com.datastax.oss.kafka.oauth;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.BoundRequestBuilder;
+import org.asynchttpclient.ListenableFuture;
+import org.asynchttpclient.Response;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -40,5 +51,41 @@ public class ClientCredentialsFlowTest {
         final ClientCredentialsFlow.ClientInfo clientInfo = flow.loadPrivateKey();
         Assert.assertEquals(clientInfo.getId(), "my-id");
         Assert.assertEquals(clientInfo.getSecret(), "my-secret");
+        Assert.assertEquals(clientInfo.getTenant(), "my-tenant");
+    }
+
+    @Test
+    public void testTenantToken() throws ExecutionException, InterruptedException, IOException {
+        AsyncHttpClient mockHttpClient = mock(AsyncHttpClient.class);
+        final ClientCredentialsFlow flow = spy(new ClientCredentialsFlow(ClientConfigHelper.create(
+                "http://localhost:4444",
+                Objects.requireNonNull(
+                        getClass().getClassLoader().getResource("private_key.json")).toString()
+        ), mockHttpClient));
+
+        ClientCredentialsFlow.Metadata mockMetadata = mock(ClientCredentialsFlow.Metadata.class);
+        doReturn("mockTokenEndPoint").when(mockMetadata).getTokenEndPoint();
+
+        doReturn(mockMetadata).when(flow).findAuthorizationServer();
+
+        BoundRequestBuilder mockBuilder = mock(BoundRequestBuilder.class);
+        ListenableFuture<Response> mockFuture = mock(ListenableFuture.class);
+        Response mockResponse = mock(Response.class);
+        doReturn(200).when(mockResponse).getStatusCode();
+        String responseString = "{\n"
+                + "    \"access_token\":\"my-token\",\n"
+                + "    \"expires_in\":42,\n"
+                + "    \"scope\":\"test\"\n"
+                + "}";
+        doReturn(responseString.getBytes()).when(mockResponse).getResponseBodyAsBytes();
+        doReturn(mockResponse).when(mockFuture).get();
+        doReturn(mockFuture).when(mockBuilder).execute();
+        doReturn(mockBuilder).when(mockHttpClient).preparePost(anyString());
+        doReturn(mockBuilder).when(mockBuilder).setHeader(anyString(), anyString());
+        doReturn(mockBuilder).when(mockBuilder).setBody(anyString());
+
+        OAuthBearerTokenImpl token = flow.authenticate();
+        Assert.assertEquals(token.value(), "my-tenant" + OAuthBearerTokenImpl.DELIMITER + "my-token");
+        Assert.assertEquals(token.scope(), Collections.singleton("test"));
     }
 }

--- a/oauth-client/src/test/java/com/datastax/oss/kafka/oauth/ClientCredentialsFlowTest.java
+++ b/oauth-client/src/test/java/com/datastax/oss/kafka/oauth/ClientCredentialsFlowTest.java
@@ -20,12 +20,12 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Objects;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Objects;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/oauth-client/src/test/resources/private_key.json
+++ b/oauth-client/src/test/resources/private_key.json
@@ -1,4 +1,5 @@
 {
   "client_id": "my-id",
-  "client_secret": "my-secret"
+  "client_secret": "my-secret",
+  "tenant": "my-tenant"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <log4j2.version>2.17.1</log4j2.version>
     <lombok.version>1.18.24</lombok.version>
     <mockito.version>2.22.0</mockito.version>
+    <wiremock.version>3.0.0-beta-2</wiremock.version>
     <pulsar.group.id>com.datastax.oss</pulsar.group.id>
     <pulsar.version>2.10.3.3</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
@@ -242,6 +243,12 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.tomakehurst</groupId>
+        <artifactId>wiremock</artifactId>
+        <version>${wiremock.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -661,6 +661,13 @@
       <url>https://repo1.maven.org/maven2</url>
     </repository>
 
+
+    <repository>
+      <id>datastax.jfrog.io</id>
+      <url>https://datastax.jfrog.io/artifactory/datastax-public-releases-local</url>
+    </repository>
+
+<!--
     <repository>
       <id>datastax-public-releases-local</id>
       <url>https://repo.datastax.com/artifactory/datastax-public-releases-local</url>
@@ -676,7 +683,7 @@
         <enabled>false</enabled>
       </releases>
     </repository>
-
+-->
   </repositories>
 
   <distributionManagement>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CustomOAuthBearerCallbackHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CustomOAuthBearerCallbackHandlerTest.java
@@ -178,6 +178,11 @@ public class CustomOAuthBearerCallbackHandlerTest extends KopProtocolHandlerTest
                         }
 
                         @Override
+                        public String tenant() {
+                            return null;
+                        }
+
+                        @Override
                         public Long startTimeMs() {
                             return null;
                         }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/HydraOAuthUtils.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/HydraOAuthUtils.java
@@ -83,6 +83,11 @@ public class HydraOAuthUtils {
     }
 
     public static String createOAuthClient(String clientId, String clientSecret) throws ApiException, IOException {
+        return createOAuthClient(clientId, clientSecret, null);
+    }
+
+    public static String createOAuthClient(String clientId, String clientSecret, String tenant)
+            throws ApiException, IOException {
         final OAuth2Client oAuth2Client = new OAuth2Client()
                 .audience(Collections.singletonList(AUDIENCE))
                 .clientId(clientId)
@@ -97,15 +102,17 @@ public class HydraOAuthUtils {
                 throw e;
             }
         }
-        return writeCredentialsFile(clientId, clientSecret, clientId + ".json");
+        return writeCredentialsFile(clientId, clientSecret, tenant, clientId + ".json");
     }
 
     public static String writeCredentialsFile(String clientId,
                                                String clientSecret,
+                                               String tenant,
                                                String basename) throws IOException {
         final String content = "{\n"
                 + "    \"client_id\": \"" + clientId + "\",\n"
-                + "    \"client_secret\": \"" + clientSecret + "\"\n"
+                + "    \"client_secret\": \"" + clientSecret + (tenant != null ? "\",\n" : "\"\n")
+                + (tenant != null ? "    \"tenant\": \"" + tenant + "\"\n" : "")
                 + "}\n";
 
         File file = File.createTempFile("oauth-credentials-", basename);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthKopHandlersTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthKopHandlersTest.java
@@ -210,8 +210,8 @@ public class SaslOAuthKopHandlersTest extends SaslOAuthBearerTestBase {
     @Test(timeOut = 15000)
     public void testWrongSecret() throws IOException {
         final Properties producerProps = newKafkaProducerProperties();
-        internalConfigureOAuth2(producerProps,
-                HydraOAuthUtils.writeCredentialsFile(ADMIN_USER, ADMIN_SECRET + "-wrong", "test-wrong-secret.json"));
+        internalConfigureOAuth2(producerProps, HydraOAuthUtils
+                .writeCredentialsFile(ADMIN_USER, ADMIN_SECRET + "-wrong", null, "test-wrong-secret.json"));
         try {
             new KafkaProducer<>(producerProps);
         } catch (Exception e) {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthKopHandlersWithMultiTenantTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthKopHandlersWithMultiTenantTest.java
@@ -1,0 +1,174 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.Sets;
+import io.streamnative.pulsar.handlers.kop.security.oauth.OauthLoginCallbackHandler;
+import io.streamnative.pulsar.handlers.kop.security.oauth.OauthValidatorCallbackHandler;
+import java.net.URL;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2;
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2;
+import org.apache.pulsar.common.policies.data.AuthAction;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class SaslOAuthKopHandlersWithMultiTenantTest extends SaslOAuthBearerTestBase {
+
+    private static final String ADMIN_USER = "simple_client_id";
+    private static final String ADMIN_SECRET = "admin_secret";
+    private static final String ISSUER_URL = "http://localhost:4444";
+    private static final String AUDIENCE = "http://example.com/api/v2/";
+
+    private String adminCredentialPath = null;
+
+    @BeforeClass(timeOut = 20000)
+    @Override
+    protected void setup() throws Exception {
+        String tokenPublicKey = HydraOAuthUtils.getPublicKeyStr();
+        adminCredentialPath = HydraOAuthUtils.createOAuthClient(ADMIN_USER, ADMIN_SECRET);
+        super.resetConfig();
+        // Broker's config
+        conf.setAuthenticationEnabled(true);
+        conf.setAuthorizationEnabled(true);
+        conf.setKafkaEnableMultiTenantMetadata(true);
+        conf.setAuthorizationProvider(SaslOAuthKopHandlersTest.OAuthMockAuthorizationProvider.class.getName());
+        conf.setAuthenticationProviders(Sets.newHashSet(AuthenticationProviderToken.class.getName()));
+        conf.setBrokerClientAuthenticationPlugin(AuthenticationOAuth2.class.getName());
+        conf.setBrokerClientAuthenticationParameters(String.format("{\"type\":\"client_credentials\","
+                        + "\"privateKey\":\"%s\",\"issuerUrl\":\"%s\",\"audience\":\"%s\"}",
+                adminCredentialPath, ISSUER_URL, AUDIENCE));
+        final Properties properties = new Properties();
+        properties.setProperty("tokenPublicKey", tokenPublicKey);
+        conf.setProperties(properties);
+
+        // KoP's config
+        conf.setSaslAllowedMechanisms(Sets.newHashSet("OAUTHBEARER"));
+        conf.setKopOauth2AuthenticateCallbackHandler(OauthValidatorCallbackHandler.class.getName());
+        conf.setKopOauth2ConfigFile("src/test/resources/kop-handler-oauth2.properties");
+
+        super.internalSetup();
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Override
+    protected void createAdmin() throws Exception {
+        super.admin = PulsarAdmin.builder()
+                .serviceHttpUrl(brokerUrl.toString())
+                .authentication(
+                        AuthenticationFactoryOAuth2.clientCredentials(
+                                new URL(ISSUER_URL), new URL(adminCredentialPath), AUDIENCE))
+                .build();
+    }
+
+    @Test(timeOut = 15000)
+    public void testGrantAndRevokePermissionToNewTenant() throws Exception {
+        SaslOAuthKopHandlersTest.OAuthMockAuthorizationProvider.NULL_ROLE_STACKS.clear();
+        String newTenant = "my-tenant";
+        admin.tenants().createTenant(newTenant,
+                TenantInfo.builder()
+                        .adminRoles(Collections.singleton(ADMIN_USER))
+                        .allowedClusters(Collections.singleton(configClusterName))
+                        .build());
+        TenantInfo tenantInfo = admin.tenants().getTenantInfo(newTenant);
+        log.info("TenantInfo for {} {} in test", newTenant, tenantInfo);
+        assertNotNull(tenantInfo);
+
+        final String namespace = newTenant + "/" + conf.getKafkaNamespace();
+        admin.namespaces().createNamespace(namespace);
+        final String topic = "persistent://" + namespace + "/test-grant-and-revoke-permission";
+        final String role = "normal-role-" + System.currentTimeMillis();
+        final String clientCredentialPath = HydraOAuthUtils.createOAuthClient(role, "secret", newTenant);
+
+        admin.namespaces().grantPermissionOnNamespace(namespace, role, Collections.singleton(AuthAction.produce));
+        final Properties consumerProps = newKafkaConsumerProperties();
+        internalConfigureOAuth2(consumerProps, clientCredentialPath);
+        final KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerProps);
+        consumer.subscribe(Collections.singleton(topic));
+        Assert.assertThrows(TopicAuthorizationException.class, () -> consumer.poll(Duration.ofSeconds(5)));
+
+        final Properties producerProps = newKafkaProducerProperties();
+        internalConfigureOAuth2(producerProps, clientCredentialPath);
+        final KafkaProducer<String, String> producer = new KafkaProducer<>(producerProps);
+        producer.send(new ProducerRecord<>(topic, "msg-0")).get();
+
+        admin.namespaces().revokePermissionsOnNamespace(namespace, role);
+        try {
+            producer.send(new ProducerRecord<>(topic, "msg-1")).get();
+            Assert.fail(role + " should not have permission to produce");
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof TopicAuthorizationException);
+        }
+
+        admin.namespaces().grantPermissionOnNamespace(namespace, role, Collections.singleton(AuthAction.consume));
+        ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(2));
+        assertEquals(records.iterator().next().value(), "msg-0");
+
+        consumer.close();
+        producer.close();
+        assertEquals(SaslOAuthKopHandlersTest.OAuthMockAuthorizationProvider.NULL_ROLE_STACKS.size(), 0);
+    }
+
+    private void internalConfigureOAuth2(final Properties props, final String credentialPath,
+                                         Class<? extends AuthenticateCallbackHandler> callbackHandler) {
+        props.setProperty("sasl.login.callback.handler.class", callbackHandler.getName());
+        props.setProperty("security.protocol", "SASL_PLAINTEXT");
+        props.setProperty("sasl.mechanism", "OAUTHBEARER");
+
+        final String jaasTemplate = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required"
+                + " oauth.issuer.url=\"%s\""
+                + " oauth.credentials.url=\"%s\""
+                + " oauth.audience=\"%s\";";
+        props.setProperty("sasl.jaas.config", String.format(jaasTemplate,
+                ISSUER_URL,
+                credentialPath,
+                AUDIENCE
+        ));
+    }
+
+    private void internalConfigureOAuth2(final Properties props, final String credentialPath) {
+        internalConfigureOAuth2(props, credentialPath, OauthLoginCallbackHandler.class);
+    }
+
+    @Override
+    protected void configureOAuth2(final Properties props) {
+        internalConfigureOAuth2(props, adminCredentialPath);
+    }
+
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthKopHandlersWithMultiTenantTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthKopHandlersWithMultiTenantTest.java
@@ -17,8 +17,8 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
+import com.datastax.oss.kafka.oauth.OauthLoginCallbackHandler;
 import com.google.common.collect.Sets;
-import io.streamnative.pulsar.handlers.kop.security.oauth.OauthLoginCallbackHandler;
 import io.streamnative.pulsar.handlers.kop.security.oauth.OauthValidatorCallbackHandler;
 import java.net.URL;
 import java.time.Duration;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthValidatorCallbackHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthValidatorCallbackHandlerTest.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.security.oauth;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import java.util.HashMap;
+import javax.naming.AuthenticationException;
+import org.apache.pulsar.broker.authentication.AuthenticationProvider;
+import org.apache.pulsar.broker.authentication.AuthenticationService;
+import org.apache.pulsar.broker.authentication.AuthenticationState;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test for {@link OauthValidatorCallbackHandler}.
+ */
+public class OauthValidatorCallbackHandlerTest {
+
+    @Test
+    public void testHandleCallback() throws AuthenticationException {
+        AuthenticationService mockAuthService = mock(AuthenticationService.class);
+        OauthValidatorCallbackHandler handler =
+                spy(new OauthValidatorCallbackHandler(new ServerConfig(new HashMap<>()), mockAuthService));
+
+        AuthenticationProvider mockAuthProvider = mock(AuthenticationProvider.class);
+
+        doReturn(mockAuthProvider).when(mockAuthService).getAuthenticationProvider(anyString());
+
+        AuthenticationState state = mock(AuthenticationState.class);
+
+        doReturn(state).when(mockAuthProvider).newAuthState(any(), any(), any());
+
+        KopOAuthBearerValidatorCallback callbackWithTenant =
+                new KopOAuthBearerValidatorCallback("my-tenant" + OAuthTokenDecoder.DELIMITER + "my-token");
+
+        handler.handleCallback(callbackWithTenant);
+
+        KopOAuthBearerToken token = callbackWithTenant.token();
+        assertEquals(token.tenant(), "my-tenant");
+        assertEquals(token.value(), "my-token");
+
+        KopOAuthBearerValidatorCallback callbackWithoutTenant =
+                new KopOAuthBearerValidatorCallback("my-token");
+        handler.handleCallback(callbackWithoutTenant);
+
+        token = callbackWithoutTenant.token();
+        assertNull(token.tenant());
+        assertEquals(token.value(), "my-token");
+    }
+
+}

--- a/tests/src/test/resources/credentials_file.json
+++ b/tests/src/test/resources/credentials_file.json
@@ -1,4 +1,5 @@
 {
   "client_id":"Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x",
-  "client_secret":"rT7ps7WY8uhdVuBTKWZkttwLdQotmdEliaM5rLfmgNibvqziZ-g07ZH52N_poGAb"
+  "client_secret":"rT7ps7WY8uhdVuBTKWZkttwLdQotmdEliaM5rLfmgNibvqziZ-g07ZH52N_poGAb",
+  "tenant": "test_tenant"
 }


### PR DESCRIPTION
Currently, KoP stores all group and offset metadata in one topic, `public/__kafka/__consumer_offsets`. It's not easy to extend and might encounter performance issues for large amount of consumers.

> in the long run as consumers keep increasing as all these consumers
share the same topic would there be slowness in committing the offsets etc.

To solve this issue, we can specify the tenant in `PLAIN` authentication's username, for example:

```
required username="public/default" password="token:xxx";
```

But when using `OAuth` authentication, there is no way to specify the tenant.

In this PR, we will introduce a way to specify tenants on OAuth authentication, and we will add a new property in
`credentials_file.json`. For example:

```json
{
  "client_id":"Xd23RHsUnvUlP7wchjNYOaIfazgeHd9x",
  "client_secret":"rT7ps7WY8uhdVuBTKWZkttwLdQotmdEliaM5rLfmgNibvqziZ-g07ZH52N_poGAb",
  "tenant": "my_tenant"
}
```

**Internal design**

The tenant will be encoded to a token sent by the client, the token format will be `{tenant} __with_tenant__{token}`, since the token only allows to `(?<token>[-_\.a-zA-Z0-9]+)`, so here used `__with_tenant__ ` as the delimiter. On the KoP server side, it will try to extract the tenant and token, the tenant will be used as KoP metadata tenant.

Add multi-tenant support for OAuth authentication.

(cherry picked from commit 55740249efc8ccc02b6d70b43471e51bb64d2b0d)