### PR TITLE
Update Kafka wireprotocol to 3.4.0 + KIP-699 + KIP-709

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedFetch.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedFetch.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.requests.FetchRequest;
+import org.apache.kafka.common.message.FetchRequestData;
 
 @Slf4j
 public class DelayedFetch extends DelayedOperation {
@@ -33,7 +33,7 @@ public class DelayedFetch extends DelayedOperation {
     private final long bytesReadable;
     private final int fetchMaxBytes;
     private final boolean readCommitted;
-    private final Map<TopicPartition, FetchRequest.PartitionData> readPartitionInfo;
+    private final Map<TopicPartition, FetchRequestData.FetchPartition> readPartitionInfo;
     private final Map<TopicPartition, PartitionLog.ReadRecordsResult> readRecordsResult;
     private final MessageFetchContext context;
     protected volatile Boolean hasError;
@@ -55,7 +55,7 @@ public class DelayedFetch extends DelayedOperation {
                         final boolean readCommitted,
                         final MessageFetchContext context,
                         final ReplicaManager replicaManager,
-                        final Map<TopicPartition, FetchRequest.PartitionData> readPartitionInfo,
+                        final Map<TopicPartition, FetchRequestData.FetchPartition> readPartitionInfo,
                         final Map<TopicPartition, PartitionLog.ReadRecordsResult> readRecordsResult,
                         final CompletableFuture<Map<TopicPartition, PartitionLog.ReadRecordsResult>> callback) {
         super(delayMs, Optional.empty());

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -453,7 +453,14 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
                                 this, request, response);
                     }
 
-                    final ByteBuf result = responseToByteBuf(response, request, true);
+                    final ByteBuf result;
+                    try {
+                        result = responseToByteBuf(response, request, true);
+                    } catch (Throwable error) {
+                        log.error("[{}] Failed to convert response {} to ByteBuf", channel, response, error);
+                        sendErrorResponse(request, channel, error, true);
+                        return;
+                    }
                     final int resultSize = result.readableBytes();
                     channel.writeAndFlush(result).addListener(future -> {
                         if (response instanceof ResponseCallbackWrapper) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -1129,7 +1129,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
 
 
         if (partitions == null || partitions.isEmpty()) {
-            authorizeFuture.complete(null);
+            authorizeFuture.complete(authorizedPartitions);
         } else {
             AtomicInteger partitionCount = new AtomicInteger(partitions.size());
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -1126,9 +1126,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         checkState(getGroupCoordinator() != null,
             "Group Coordinator not started");
 
-        log.info("handleOffsetFetchRequest grouId {} groups {} version {}", request.data().groupId(),
-                request.data().groups(), offsetFetch.getRequest().version());
-
         List<CompletableFuture<KafkaResponseUtils.OffsetFetchResponseGroupData>> futures = new ArrayList<>();
         if (request.version() >= 8) {
             request.data().groups().forEach(group -> {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -1915,7 +1915,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 joinGroupResult.getProtocolType(),
                 joinGroupResult.getMemberId(),
                 joinGroupResult.getLeaderId(),
-                members
+                members,
+                request.version()
             );
             if (log.isTraceEnabled()) {
                 log.trace("Sending join group response {} for correlation id {} to client {}.",

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -831,8 +831,13 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             }
             disableCnxAutoRead();
             autoReadDisabledPublishBufferLimiting = true;
-            pulsarService.getBrokerService().pausedConnections(1);
+            setPausedConnections(pulsarService, 1);
         }
+    }
+
+    @VisibleForTesting
+    public static void setPausedConnections(PulsarService pulsarService, int numConnections) {
+        pulsarService.getBrokerService().pausedConnections(numConnections);
     }
 
     private void completeSendOperationForThrottling(long msgSize) {
@@ -844,8 +849,13 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             }
             autoReadDisabledPublishBufferLimiting = false;
             enableCnxAutoRead();
-            pulsarService.getBrokerService().resumedConnections(1);
+            resumePausedConnections(pulsarService, 1);
         }
+    }
+
+    @VisibleForTesting
+    public static void resumePausedConnections(PulsarService pulsarService, int numConnections) {
+        pulsarService.getBrokerService().resumedConnections(numConnections);
     }
 
     @Override

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -78,12 +78,12 @@ import org.apache.kafka.common.errors.KafkaStorageException;
 import org.apache.kafka.common.errors.NotLeaderOrFollowerException;
 import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.common.errors.UnknownServerException;
+import org.apache.kafka.common.message.FetchRequestData;
+import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.RecordBatch;
-import org.apache.kafka.common.record.Records;
-import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.requests.FetchResponse;
 import org.apache.kafka.common.utils.Time;
 import org.apache.pulsar.broker.service.Topic;
@@ -304,7 +304,7 @@ public class PartitionLog {
         private final Recycler.Handle<ReadRecordsResult> recyclerHandle;
 
         private DecodeResult decodeResult;
-        private List<FetchResponse.AbortedTransaction> abortedTransactions;
+        private List<FetchResponseData.AbortedTransaction> abortedTransactions;
         private long highWatermark;
         private long lastStableOffset;
         private Position lastPosition;
@@ -321,7 +321,7 @@ public class PartitionLog {
         }
 
         public static ReadRecordsResult get(DecodeResult decodeResult,
-                                            List<FetchResponse.AbortedTransaction> abortedTransactions,
+                                            List<FetchResponseData.AbortedTransaction> abortedTransactions,
                                             long highWatermark,
                                             long lastStableOffset,
                                             Position lastPosition,
@@ -337,7 +337,7 @@ public class PartitionLog {
         }
 
         public static ReadRecordsResult get(DecodeResult decodeResult,
-                                            List<FetchResponse.AbortedTransaction> abortedTransactions,
+                                            List<FetchResponseData.AbortedTransaction> abortedTransactions,
                                             long highWatermark,
                                             long lastStableOffset,
                                             Position lastPosition,
@@ -368,7 +368,7 @@ public class PartitionLog {
                     partitionLog);
         }
 
-        public FetchResponse.PartitionData<Records> toPartitionData() {
+        public FetchResponseData.PartitionData toPartitionData() {
 
             // There are three cases:
             //
@@ -379,21 +379,20 @@ public class PartitionLog {
             // 3. errors == Others error :
             //        Get errors.
             if (errors != null) {
-                return new FetchResponse.PartitionData<>(
-                        errors,
-                        FetchResponse.INVALID_HIGHWATERMARK,
-                        FetchResponse.INVALID_LAST_STABLE_OFFSET,
-                        FetchResponse.INVALID_LOG_START_OFFSET,
-                        null,
-                        MemoryRecords.EMPTY);
+                return new FetchResponseData.PartitionData()
+                        .setErrorCode(errors.code())
+                        .setHighWatermark(FetchResponse.INVALID_HIGH_WATERMARK)
+                        .setLastStableOffset(FetchResponse.INVALID_LAST_STABLE_OFFSET)
+                        .setLogStartOffset(FetchResponse.INVALID_LOG_START_OFFSET)
+                        .setRecords(MemoryRecords.EMPTY);
             }
-            return new FetchResponse.PartitionData<>(
-                    Errors.NONE,
-                    highWatermark,
-                    lastStableOffset,
-                    highWatermark, // TODO: should it be changed to the logStartOffset?
-                    abortedTransactions,
-                    decodeResult.getRecords());
+            return new FetchResponseData.PartitionData()
+                    .setErrorCode(Errors.NONE.code())
+                    .setHighWatermark(highWatermark)
+                    .setLastStableOffset(lastStableOffset)
+                    .setHighWatermark(highWatermark) // TODO: should it be changed to the logStartOffset?
+                    .setAbortedTransactions(abortedTransactions)
+                    .setRecords(decodeResult.getRecords());
         }
 
         public void recycle() {
@@ -460,7 +459,7 @@ public class PartitionLog {
         return producerStateManager.firstUndecidedOffset();
     }
 
-    public List<FetchResponse.AbortedTransaction> getAbortedIndexList(long fetchOffset) {
+    public List<FetchResponseData.AbortedTransaction> getAbortedIndexList(long fetchOffset) {
         return producerStateManager.getAbortedIndexList(fetchOffset);
     }
 
@@ -538,14 +537,14 @@ public class PartitionLog {
         return persistentTopic.getLastPosition();
     }
 
-    public CompletableFuture<ReadRecordsResult> readRecords(final FetchRequest.PartitionData partitionData,
+    public CompletableFuture<ReadRecordsResult> readRecords(final FetchRequestData.FetchPartition partitionData,
                                                             final boolean readCommitted,
                                                             final AtomicLong limitBytes,
                                                             final int maxReadEntriesNum,
                                                             final MessageFetchContext context) {
         final long startPrepareMetadataNanos = MathUtils.nowInNano();
         final CompletableFuture<ReadRecordsResult> future = new CompletableFuture<>();
-        final long offset = partitionData.fetchOffset;
+        final long offset = partitionData.fetchOffset();
         KafkaTopicManager topicManager = context.getTopicManager();
         // The future that is returned by getTopicConsumerManager is always completed normally
         topicManager.getTopicConsumerManager(fullPartitionName).thenAccept(tcm -> {
@@ -593,7 +592,7 @@ public class PartitionLog {
 
                 requestStats.getPrepareMetadataStats().registerSuccessfulEvent(
                         MathUtils.elapsedNanos(startPrepareMetadataNanos), TimeUnit.NANOSECONDS);
-                long adjustedMaxBytes = Math.min(partitionData.maxBytes, limitBytes.get());
+                long adjustedMaxBytes = Math.min(partitionData.partitionMaxBytes(), limitBytes.get());
                 readEntries(cursor, topicPartition, cursorOffset, maxReadEntriesNum, adjustedMaxBytes,
                         fullPartitionName -> {
                     topicManager.invalidateCacheForFencedManagerLedgerOnTopic(fullPartitionName);
@@ -661,7 +660,7 @@ public class PartitionLog {
 
     private void handleEntries(final CompletableFuture<ReadRecordsResult> future,
                                final List<Entry> entries,
-                               final FetchRequest.PartitionData partitionData,
+                               final FetchRequestData.FetchPartition partitionData,
                                final KafkaTopicConsumerManager tcm,
                                final ManagedCursor cursor,
                                final boolean readCommitted,
@@ -707,9 +706,9 @@ public class PartitionLog {
 
                 // collect consumer metrics
                 decodeResult.updateConsumerStats(topicPartition, committedEntries.size(), groupName, requestStats);
-                List<FetchResponse.AbortedTransaction> abortedTransactions = null;
+                List<FetchResponseData.AbortedTransaction> abortedTransactions = null;
                 if (readCommitted) {
-                    abortedTransactions = this.getAbortedIndexList(partitionData.fetchOffset);
+                    abortedTransactions = this.getAbortedIndexList(partitionData.fetchOffset());
                 }
                 if (log.isDebugEnabled()) {
                     log.debug("Partition {} read entry completed in {} ns",

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
@@ -27,8 +27,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.util.SafeRunnable;
+import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.record.RecordBatch;
-import org.apache.kafka.common.requests.FetchResponse;
 
 /**
  * Producer state manager.
@@ -355,13 +355,15 @@ public class ProducerStateManager {
         return count.get();
     }
 
-    public List<FetchResponse.AbortedTransaction> getAbortedIndexList(long fetchOffset) {
+    public List<FetchResponseData.AbortedTransaction> getAbortedIndexList(long fetchOffset) {
         synchronized (abortedIndexList) {
-            List<FetchResponse.AbortedTransaction> abortedTransactions = new ArrayList<>();
+            List<FetchResponseData.AbortedTransaction> abortedTransactions = new ArrayList<>();
             for (AbortedTxn abortedTxn : abortedIndexList) {
                 if (abortedTxn.lastOffset() >= fetchOffset) {
                     abortedTransactions.add(
-                            new FetchResponse.AbortedTransaction(abortedTxn.producerId(), abortedTxn.firstOffset()));
+                            new FetchResponseData.AbortedTransaction()
+                                    .setProducerId(abortedTxn.producerId())
+                                    .setFirstOffset(abortedTxn.firstOffset()));
                 }
             }
             return abortedTransactions;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -43,9 +43,9 @@ import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.NotLeaderOrFollowerException;
+import org.apache.kafka.common.message.FetchRequestData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.MemoryRecords;
-import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.requests.ProduceResponse;
 import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
@@ -236,7 +236,7 @@ public class ReplicaManager {
             final long timeout,
             final int fetchMinBytes,
             final int fetchMaxBytes,
-            final ConcurrentHashMap<TopicPartition, FetchRequest.PartitionData> fetchInfos,
+            final ConcurrentHashMap<TopicPartition, FetchRequestData.FetchPartition> fetchInfos,
             final IsolationLevel isolationLevel,
             final MessageFetchContext context) {
         CompletableFuture<Map<TopicPartition, PartitionLog.ReadRecordsResult>> future =
@@ -290,7 +290,7 @@ public class ReplicaManager {
             final boolean readCommitted,
             final int fetchMaxBytes,
             final int maxReadEntriesNum,
-            final Map<TopicPartition, FetchRequest.PartitionData> readPartitionInfo,
+            final Map<TopicPartition, FetchRequestData.FetchPartition> readPartitionInfo,
             final MessageFetchContext context) {
         AtomicLong limitBytes = new AtomicLong(fetchMaxBytes);
         CompletableFuture<Map<TopicPartition, PartitionLog.ReadRecordsResult>> resultFuture = new CompletableFuture<>();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KafkaResponseUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KafkaResponseUtils.java
@@ -57,6 +57,7 @@ import org.apache.kafka.common.requests.DeleteGroupsResponse;
 import org.apache.kafka.common.requests.DeleteRecordsResponse;
 import org.apache.kafka.common.requests.DeleteTopicsResponse;
 import org.apache.kafka.common.requests.DescribeGroupsResponse;
+import org.apache.kafka.common.requests.FindCoordinatorRequest;
 import org.apache.kafka.common.requests.FindCoordinatorResponse;
 import org.apache.kafka.common.requests.HeartbeatResponse;
 import org.apache.kafka.common.requests.JoinGroupResponse;
@@ -190,7 +191,7 @@ public class KafkaResponseUtils {
     public static FindCoordinatorResponse newFindCoordinator(Node node, String key, int version) {
         FindCoordinatorResponseData data = new FindCoordinatorResponseData();
 
-        if (version <= 3) {
+        if (version < FindCoordinatorRequest.MIN_BATCHED_VERSION) {
             // for old clients
             data.setNodeId(node.id());
             data.setHost(node.host());
@@ -215,7 +216,7 @@ public class KafkaResponseUtils {
 
     public static FindCoordinatorResponse newFindCoordinator(Errors errors, String key, int version) {
         FindCoordinatorResponseData data = new FindCoordinatorResponseData();
-        if (version <= 3) {
+        if (version < FindCoordinatorRequest.MIN_BATCHED_VERSION) {
             // for old clients
             data.setErrorCode(errors.code());
             data.setErrorMessage(errors.message());

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KafkaResponseUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KafkaResponseUtils.java
@@ -247,7 +247,8 @@ public class KafkaResponseUtils {
                                                  String groupProtocolType,
                                                  String memberId,
                                                  String leaderId,
-                                                 Map<String, byte[]> groupMembers) {
+                                                 Map<String, byte[]> groupMembers,
+                                                 short requestVersion) {
         JoinGroupResponseData data = new JoinGroupResponseData()
                 .setErrorCode(errors.code())
                 .setLeader(leaderId)
@@ -269,7 +270,7 @@ public class KafkaResponseUtils {
             data.setThrottleTimeMs(1000);
         }
 
-        return new JoinGroupResponse(data, ApiKeys.JOIN_GROUP.latestVersion());
+        return new JoinGroupResponse(data, requestVersion);
     }
 
     public static LeaveGroupResponse newLeaveGroup(Errors errors) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KafkaResponseUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KafkaResponseUtils.java
@@ -44,6 +44,7 @@ import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.message.SaslAuthenticateResponseData;
 import org.apache.kafka.common.message.SaslHandshakeResponseData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractResponse;
 import org.apache.kafka.common.requests.ApiError;
@@ -234,7 +235,7 @@ public class KafkaResponseUtils {
             data.setThrottleTimeMs(1000);
         }
 
-        return new JoinGroupResponse(data);
+        return new JoinGroupResponse(data, ApiKeys.JOIN_GROUP.latestVersion());
     }
 
     public static LeaveGroupResponse newLeaveGroup(Errors errors) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KafkaResponseUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KafkaResponseUtils.java
@@ -46,7 +46,6 @@ import org.apache.kafka.common.message.OffsetFetchResponseData;
 import org.apache.kafka.common.message.SaslAuthenticateResponseData;
 import org.apache.kafka.common.message.SaslHandshakeResponseData;
 import org.apache.kafka.common.message.SyncGroupResponseData;
-import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractResponse;
 import org.apache.kafka.common.requests.ApiError;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KafkaResponseUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KafkaResponseUtils.java
@@ -16,7 +16,6 @@ package io.streamnative.pulsar.handlers.kop.utils;
 import io.streamnative.pulsar.handlers.kop.ApiVersion;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadata;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +24,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
@@ -72,6 +72,7 @@ import org.apache.kafka.common.requests.SaslHandshakeResponse;
 import org.apache.kafka.common.requests.SyncGroupResponse;
 import org.apache.pulsar.common.schema.KeyValue;
 
+@Slf4j
 public class KafkaResponseUtils {
 
     public static ApiVersionsResponse newApiVersions(List<ApiVersion> versionList) {
@@ -188,47 +189,51 @@ public class KafkaResponseUtils {
         return new DescribeGroupsResponse(data);
     }
 
-    public static FindCoordinatorResponse newFindCoordinator(Node node, String key, int version) {
+    public static FindCoordinatorResponse newFindCoordinator(List<String> coordinatorKeys,
+                                                             Node node,
+                                                             int version) {
         FindCoordinatorResponseData data = new FindCoordinatorResponseData();
-
         if (version < FindCoordinatorRequest.MIN_BATCHED_VERSION) {
-            // for old clients
-            data.setNodeId(node.id());
-            data.setHost(node.host());
-            data.setPort(node.port());
-            data.setErrorCode(Errors.NONE.code());
-            data.setErrorMessage(Errors.NONE.message());
-            data.setCoordinators(Collections.emptyList());
-        } else {
-
-            // for new clients
-            data.setCoordinators(Arrays.asList(new FindCoordinatorResponseData.Coordinator()
-                    .setHost(node.host())
-                    .setPort(node.port())
-                    .setNodeId(node.id())
+            data.setErrorMessage(Errors.NONE.message())
                     .setErrorCode(Errors.NONE.code())
-                    .setKey(key)
-                    .setErrorMessage(Errors.NONE.message())));
-        }
-
-        return new FindCoordinatorResponse(data);
-    }
-
-    public static FindCoordinatorResponse newFindCoordinator(Errors errors, String key, int version) {
-        FindCoordinatorResponseData data = new FindCoordinatorResponseData();
-        if (version < FindCoordinatorRequest.MIN_BATCHED_VERSION) {
-            // for old clients
-            data.setErrorCode(errors.code());
-            data.setErrorMessage(errors.message());
+                    .setPort(node.port())
+                    .setHost(node.host())
+                    .setNodeId(node.id());
         } else {
             // for new clients
-            data.setCoordinators(Arrays.asList(new FindCoordinatorResponseData.Coordinator()
-                    .setErrorCode(errors.code())
-                    .setKey(key)
-                    .setErrorMessage(errors.message())));
+            data.setCoordinators(coordinatorKeys
+                    .stream()
+                    .map(key -> new FindCoordinatorResponseData.Coordinator()
+                            .setErrorCode(Errors.NONE.code())
+                            .setErrorMessage(Errors.NONE.message())
+                            .setHost(node.host())
+                            .setPort(node.port())
+                            .setNodeId(node.id())
+                            .setKey(key))
+                    .collect(Collectors.toList()));
         }
+
         return new FindCoordinatorResponse(data);
     }
+
+    public static FindCoordinatorResponse newFindCoordinator(List<FindCoordinatorResponseData.Coordinator> coordinators,
+                                                             int version) {
+        FindCoordinatorResponseData data = new FindCoordinatorResponseData();
+        if (version < FindCoordinatorRequest.MIN_BATCHED_VERSION) {
+            FindCoordinatorResponseData.Coordinator coordinator = coordinators.get(0);
+            data.setErrorMessage(coordinator.errorMessage())
+                    .setErrorCode(coordinator.errorCode())
+                    .setPort(coordinator.port())
+                    .setHost(coordinator.host())
+                    .setNodeId(coordinator.nodeId());
+        } else {
+            // for new clients
+            data.setCoordinators(coordinators);
+        }
+
+        return new FindCoordinatorResponse(data);
+    }
+
 
     public static HeartbeatResponse newHeartbeat(Errors errors) {
         HeartbeatResponseData data = new HeartbeatResponseData();
@@ -377,6 +382,7 @@ public class KafkaResponseUtils {
         return new MetadataResponse(data, apiVersion);
     }
 
+
     @Getter
     @AllArgsConstructor
     public static class BrokerLookupResult {
@@ -466,41 +472,56 @@ public class KafkaResponseUtils {
         return new SyncGroupResponse(data);
     }
 
+    @AllArgsConstructor
+    public static class OffsetFetchResponseGroupData {
+        String groupId;
+        Errors errors;
+        Map<TopicPartition, OffsetFetchResponse.PartitionData> partitionsResponses;
+    }
+
     public static OffsetFetchResponse buildOffsetFetchResponse(
-            Map<TopicPartition, OffsetFetchResponse.PartitionData> partitionsResponses,
-            Errors errors, int version, String groupId) {
+            List<OffsetFetchResponseGroupData> groups,
+            int version) {
 
         if (version < 8) {
             // old clients
-            return new OffsetFetchResponse(errors, partitionsResponses);
+            OffsetFetchResponseGroupData offsetFetchResponseGroupData = groups.get(0);
+            return new OffsetFetchResponse(offsetFetchResponseGroupData.errors,
+                    offsetFetchResponseGroupData.partitionsResponses);
         } else {
             // new clients
             OffsetFetchResponseData data = new OffsetFetchResponseData();
-            OffsetFetchResponseData.OffsetFetchResponseGroup offsetFetchResponseGroup =
-                    new OffsetFetchResponseData.OffsetFetchResponseGroup()
-                    .setErrorCode(errors.code())
-                    .setGroupId(groupId)
-                    .setTopics(new ArrayList<>());
-            data.groups().add(offsetFetchResponseGroup);
-            Set<String> topics = partitionsResponses.keySet().stream().map(TopicPartition::topic)
-                    .collect(Collectors.toSet());
-            topics.forEach(topic -> {
-                offsetFetchResponseGroup.topics().add(new OffsetFetchResponseData.OffsetFetchResponseTopics()
-                        .setName(topic)
-                        .setPartitions(partitionsResponses.entrySet()
-                                .stream()
-                                .filter(e -> e.getKey().topic().equals(topic))
-                                .map(entry -> {
-                                    OffsetFetchResponse.PartitionData value = entry.getValue();
-                                    return new OffsetFetchResponseData.OffsetFetchResponsePartitions()
-                                            .setErrorCode(value.error.code())
-                                            .setMetadata(value.metadata)
-                                            .setPartitionIndex(entry.getKey().partition())
-                                            .setCommittedOffset(value.offset)
-                                            .setCommittedLeaderEpoch(value.leaderEpoch.orElse(-1));
-                                })
-                                .collect(Collectors.toList())));
-            });
+            for (OffsetFetchResponseGroupData groupData : groups) {
+                OffsetFetchResponseData.OffsetFetchResponseGroup offsetFetchResponseGroup =
+                        new OffsetFetchResponseData.OffsetFetchResponseGroup()
+                                .setErrorCode(groupData.errors.code())
+                                .setGroupId(groupData.groupId)
+                                .setTopics(new ArrayList<>());
+                data.groups().add(offsetFetchResponseGroup);
+                Set<String> topics = groupData.partitionsResponses.keySet().stream().map(TopicPartition::topic)
+                        .collect(Collectors.toSet());
+                topics.forEach(topic -> {
+                    offsetFetchResponseGroup.topics().add(new OffsetFetchResponseData.OffsetFetchResponseTopics()
+                            .setName(topic)
+                            .setPartitions(groupData.partitionsResponses.entrySet()
+                                    .stream()
+                                    .filter(e -> e.getKey().topic().equals(topic))
+                                    .map(entry -> {
+                                        OffsetFetchResponse.PartitionData value = entry.getValue();
+                                        if (log.isDebugEnabled()) {
+                                            log.debug("Add resp for group {} topic {}: {}",
+                                                    groupData.groupId, topic, value);
+                                        }
+                                        return new OffsetFetchResponseData.OffsetFetchResponsePartitions()
+                                                .setErrorCode(value.error.code())
+                                                .setMetadata(value.metadata)
+                                                .setPartitionIndex(entry.getKey().partition())
+                                                .setCommittedOffset(value.offset)
+                                                .setCommittedLeaderEpoch(value.leaderEpoch.orElse(-1));
+                                    })
+                                    .collect(Collectors.toList())));
+                });
+            }
             return new OffsetFetchResponse(data);
         }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MessageMetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MessageMetadataUtils.java
@@ -38,6 +38,10 @@ import org.apache.pulsar.common.protocol.Commands;
 @Slf4j
 public class MessageMetadataUtils {
 
+    public static boolean isInterceptorConfigured(ManagedLedger managedLedger) {
+        return managedLedger.getManagedLedgerInterceptor() instanceof ManagedLedgerInterceptorImpl;
+    }
+
     public static long getCurrentOffset(ManagedLedger managedLedger) {
         return ((ManagedLedgerInterceptorImpl) managedLedger.getManagedLedgerInterceptor()).getIndex();
     }

--- a/kafka-impl/src/main/java/org/apache/kafka/common/requests/ResponseCallbackWrapper.java
+++ b/kafka-impl/src/main/java/org/apache/kafka/common/requests/ResponseCallbackWrapper.java
@@ -56,4 +56,9 @@ public class ResponseCallbackWrapper extends AbstractResponse {
     public ApiMessage data() {
         return abstractResponse.data();
     }
+
+    @Override
+    public void maybeSetThrottleTimeMs(int i) {
+        abstractResponse.maybeSetThrottleTimeMs(i);
+    }
 }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
@@ -342,15 +342,15 @@ public class EntryFormatterTest {
         }
 
         @Override
-        public Long appendWithOffset(long offset, SimpleRecord record) {
-            return appendWithOffset(offset,
+        public void appendWithOffset(long offset, SimpleRecord record) {
+            appendWithOffset(offset,
                     record.timestamp(),
                     record.key(),
                     record.value(),
                     record.headers());
         }
 
-        public Long appendWithOffset(long offset,
+        public void appendWithOffset(long offset,
                                      long timestamp,
                                      ByteBuffer key,
                                      ByteBuffer value,
@@ -362,9 +362,9 @@ public class EntryFormatterTest {
 
                 if (magic > RecordBatch.MAGIC_VALUE_V1) {
                     appendDefaultRecord(offset, timestamp, key, value, headers);
-                    return null;
+
                 } else {
-                    return appendLegacyRecord(offset, timestamp, key, value);
+                    appendLegacyRecord(offset, timestamp, key, value);
                 }
             } catch (IOException e) {
                 throw new KafkaException("I/O exception when writing to the append stream, closing", e);

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <!-- dependencies -->
     <jackson.version>2.14.0</jackson.version>
     <jackson-databind.version>2.13.4.1</jackson-databind.version>
-    <kafka.version>2.8.2</kafka.version>
+    <kafka.version>3.4.0</kafka.version>
     <log4j2.version>2.17.1</log4j2.version>
     <lombok.version>1.18.24</lombok.version>
     <mockito.version>2.22.0</mockito.version>
@@ -95,7 +95,7 @@
     <connection>scm:git:git@github.com:datastax/starlight-for-kafka.git</connection>
     <developerConnection>scm:git:git@github.com:datastax/starlight-for-kafka.git</developerConnection>
     <url>https://github.com/datastax/starlight-for-kafka</url>
-    <tag>v2.8.0.1.0.17</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <kafka.version>3.4.0</kafka.version>
     <log4j2.version>2.17.1</log4j2.version>
     <lombok.version>1.18.24</lombok.version>
-    <mockito.version>2.22.0</mockito.version>
+    <mockito.version>3.4.0</mockito.version>
     <wiremock.version>3.0.0-beta-2</wiremock.version>
     <pulsar.group.id>com.datastax.oss</pulsar.group.id>
     <pulsar.version>2.10.3.3</pulsar.version>
@@ -242,6 +242,12 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-inline</artifactId>
         <version>${mockito.version}</version>
       </dependency>
 

--- a/proxy/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProxyRequestHandler.java
+++ b/proxy/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProxyRequestHandler.java
@@ -1853,7 +1853,8 @@ public class KafkaProxyRequestHandler extends KafkaCommandDecoder {
         OffsetFetchRequest offsetFetchRequest = (OffsetFetchRequest) kafkaHeaderAndRequest.getRequest();
         if (kafkaHeaderAndRequest.getRequest().version() < 8) {
             singleGroupId = offsetFetchRequest.groupId();
-        } else if (kafkaHeaderAndRequest.getRequest().version() > 8 && offsetFetchRequest.groupIds().size() == 1) {
+        } else if (kafkaHeaderAndRequest.getRequest().version() >= 8
+                && offsetFetchRequest.groupIds().size() == 1) {
             singleGroupId = offsetFetchRequest.groupIds().get(0);
         } else {
             singleGroupId = null;

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -100,6 +100,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
@@ -76,7 +76,7 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
         assertEquals(kafkaReceives, expectedMessages);
     }
 
-    @Test(timeOut = 200000000)
+    @Test(timeOut = 20000)
     public void testDeleteClosedTopics() throws Exception {
         final String topic = "test-delete-closed-topics";
         final List<String> expectedMessages = Collections.singletonList("msg");

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
@@ -76,7 +76,7 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
         assertEquals(kafkaReceives, expectedMessages);
     }
 
-    @Test(timeOut = 20000)
+    @Test(timeOut = 200000000)
     public void testDeleteClosedTopics() throws Exception {
         final String topic = "test-delete-closed-topics";
         final List<String> expectedMessages = Collections.singletonList("msg");

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -79,6 +79,7 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         kConfig.setOffsetsTopicNumPartitions(offsetsTopicNumPartitions);
 
         kConfig.setAdvertisedAddress("localhost");
+        kConfig.setKafkaTransactionCoordinatorEnabled(true);
         kConfig.setClusterName(configClusterName);
         kConfig.setManagedLedgerCacheSizeMB(8);
         kConfig.setActiveConsumerFailoverDelayTimeMillis(0);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimeKafkaFormatTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimeKafkaFormatTest.java
@@ -92,7 +92,7 @@ public class EntryPublishTimeKafkaFormatTest extends EntryPublishTimeTest {
 
         // time before first message
         ListOffsetsRequest.Builder builder = ListOffsetsRequest.Builder
-                .forConsumer(true, IsolationLevel.READ_UNCOMMITTED)
+                .forConsumer(true, IsolationLevel.READ_UNCOMMITTED, false)
                 .setTargetTimes(KafkaCommonTestUtils.newListOffsetTargetTimes(tp, startTime));
 
         KafkaCommandDecoder.KafkaHeaderAndRequest request = buildRequest(builder);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -71,10 +71,12 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.FindCoordinatorRequestData;
 import org.apache.kafka.common.message.ListOffsetsResponseData;
 import org.apache.kafka.common.message.OffsetCommitRequestData;
 import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.CompressionType;
@@ -107,6 +109,7 @@ import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.jetbrains.annotations.NotNull;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -283,7 +286,7 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
 
         // 2. real test, for ListOffset request verify Earliest get earliest
         ListOffsetsRequest.Builder builder = ListOffsetsRequest.Builder
-            .forConsumer(true, IsolationLevel.READ_UNCOMMITTED)
+            .forConsumer(true, IsolationLevel.READ_UNCOMMITTED, false)
             .setTargetTimes(KafkaCommonTestUtils.newListOffsetTargetTimes(tp, EARLIEST_TIMESTAMP));
 
         KafkaHeaderAndRequest request = buildRequest(builder);
@@ -336,7 +339,7 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
 
         // 2. real test, for ListOffset request verify Earliest get earliest
         ListOffsetsRequest.Builder builder = ListOffsetsRequest.Builder
-            .forConsumer(true, IsolationLevel.READ_UNCOMMITTED)
+            .forConsumer(true, IsolationLevel.READ_UNCOMMITTED, false)
             .setTargetTimes(KafkaCommonTestUtils.newListOffsetTargetTimes(tp, ListOffsetsRequest.LATEST_TIMESTAMP));
 
         KafkaHeaderAndRequest request = buildRequest(builder);
@@ -570,7 +573,7 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
 
     private ListOffsetsResponse listOffset(long timestamp, TopicPartition tp) throws Exception {
         ListOffsetsRequest.Builder builder = ListOffsetsRequest.Builder
-                .forConsumer(true, IsolationLevel.READ_UNCOMMITTED)
+                .forConsumer(true, IsolationLevel.READ_UNCOMMITTED, false)
                 .setTargetTimes(KafkaCommonTestUtils.newListOffsetTargetTimes(tp, timestamp));
 
         KafkaHeaderAndRequest request = buildRequest(builder);
@@ -584,21 +587,24 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
 
     /// Add test for FetchRequest
     private void checkFetchResponse(List<TopicPartition> expectedPartitions,
-                                    FetchResponse<MemoryRecords> fetchResponse,
+                                    FetchResponse fetchResponse,
                                     int maxPartitionBytes,
                                     int maxResponseBytes,
                                     int numMessagesPerPartition) {
 
-        assertEquals(expectedPartitions.size(), fetchResponse.responseData().size());
-        expectedPartitions.forEach(tp -> assertTrue(fetchResponse.responseData().get(tp) != null));
+        assertEquals(expectedPartitions.size(), fetchResponse
+                .data().responses().stream().mapToInt(r->r.partitions().size()));
+        expectedPartitions.forEach(tp
+                -> assertTrue(getPartitionDataFromFetchResponse(fetchResponse, tp) != null));
 
         final AtomicBoolean emptyResponseSeen = new AtomicBoolean(false);
         AtomicInteger responseSize = new AtomicInteger(0);
         AtomicInteger responseBufferSize = new AtomicInteger(0);
 
         expectedPartitions.forEach(tp -> {
-            FetchResponse.PartitionData partitionData = fetchResponse.responseData().get(tp);
-            assertEquals(Errors.NONE, partitionData.error());
+            FetchResponseData.PartitionData partitionData = getPartitionDataFromFetchResponse(fetchResponse, tp);
+
+            assertEquals(Errors.NONE.code(), partitionData.errorCode());
             assertTrue(partitionData.highWatermark() > 0);
 
             MemoryRecords records = (MemoryRecords) partitionData.records();
@@ -629,6 +635,18 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
         // In Kop implementation, fetch at least 1 item for each topicPartition in the request.
     }
 
+    @NotNull
+    private static FetchResponseData.PartitionData getPartitionDataFromFetchResponse(FetchResponse fetchResponse,
+                                                                                     TopicPartition tp) {
+        FetchResponseData.PartitionData partitionData = fetchResponse
+                .data()
+                        .responses().stream().filter(t->t.topic().equals(tp.topic()))
+                        .flatMap(r-> r.partitions().stream())
+                                .filter(p -> p.partitionIndex() == tp.partition())
+                                        .findFirst().orElse(null);
+        return partitionData;
+    }
+
     private Map<TopicPartition, FetchRequest.PartitionData> createPartitionMap(int maxPartitionBytes,
                                                                                List<TopicPartition> topicPartitions,
                                                                                Map<TopicPartition, Long> offsetMap) {
@@ -647,7 +665,8 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
                                                      Map<TopicPartition, Long> offsetMap) {
 
         AbstractRequest.Builder builder = FetchRequest.Builder
-            .forConsumer(Integer.MAX_VALUE, 0, createPartitionMap(maxPartitionBytes, topicPartitions, offsetMap))
+            .forConsumer(ApiKeys.FETCH.latestVersion(),
+                    Integer.MAX_VALUE, 0, createPartitionMap(maxPartitionBytes, topicPartitions, offsetMap))
             .setMaxBytes(maxResponseBytes);
 
         return buildRequest(builder);
@@ -797,8 +816,8 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
             Collections.EMPTY_MAP);
         CompletableFuture<AbstractResponse> responseFuture1 = new CompletableFuture<>();
         kafkaRequestHandler.handleFetchRequest(fetchRequest1, responseFuture1);
-        FetchResponse<MemoryRecords> fetchResponse1 =
-            (FetchResponse<MemoryRecords>) responseFuture1.get();
+        FetchResponse fetchResponse1 =
+            (FetchResponse) responseFuture1.get();
 
         checkFetchResponse(shuffledTopicPartitions1, fetchResponse1,
             maxPartitionBytes, maxResponseBytes, messagesPerPartition);
@@ -816,8 +835,8 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
             Collections.EMPTY_MAP);
         CompletableFuture<AbstractResponse> responseFuture2 = new CompletableFuture<>();
         kafkaRequestHandler.handleFetchRequest(fetchRequest2, responseFuture2);
-        FetchResponse<MemoryRecords> fetchResponse2 =
-            (FetchResponse<MemoryRecords>) responseFuture2.get();
+        FetchResponse fetchResponse2 =
+            (FetchResponse) responseFuture2.get();
 
         checkFetchResponse(shuffledTopicPartitions2, fetchResponse2,
             maxPartitionBytes, maxResponseBytes, messagesPerPartition);
@@ -838,8 +857,8 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
             offsetMaps);
         CompletableFuture<AbstractResponse> responseFuture3 = new CompletableFuture<>();
         kafkaRequestHandler.handleFetchRequest(fetchRequest3, responseFuture3);
-        FetchResponse<MemoryRecords> fetchResponse3 =
-            (FetchResponse<MemoryRecords>) responseFuture3.get();
+        FetchResponse fetchResponse3 =
+            (FetchResponse) responseFuture3.get();
 
         checkFetchResponse(shuffledTopicPartitions3, fetchResponse3,
             maxPartitionBytes, maxResponseBytes, messagesPerPartition);
@@ -983,7 +1002,7 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
 
         TopicPartition tp = new TopicPartition(topicName, 0);
         ListOffsetsRequest.Builder builder = ListOffsetsRequest.Builder
-            .forConsumer(false, IsolationLevel.READ_UNCOMMITTED)
+            .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false)
             .setTargetTimes(KafkaCommonTestUtils.newListOffsetTargetTimes(tp, ListOffsetsRequest.LATEST_TIMESTAMP));
 
         KafkaHeaderAndRequest request = buildRequest(builder);
@@ -1077,11 +1096,17 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
                 ApiKeys.PRODUCE.latestVersion(), produceRequestData));
         final CompletableFuture<AbstractResponse> future = new CompletableFuture<>();
         kafkaRequestHandler.handleProduceRequest(request, future);
-        final ProduceResponse.PartitionResponse response =
-                ((ProduceResponse) future.get()).responses().get(topicPartition);
+        final ProduceResponseData.PartitionProduceResponse response =
+                ((ProduceResponse) future.get()).data().responses()
+                        .stream()
+                        .filter(r->r.name().equals(topicPartition.topic()))
+                        .flatMap(r->r.partitionResponses().stream())
+                        .filter(p->p.index() == topicPartition.partition())
+                        .findFirst()
+                        .get();
         assertNotNull(response);
-        assertEquals(response.error, expectedError);
-        assertEquals(response.baseOffset, expectedOffset);
+        assertEquals(response.errorCode(), expectedError.code());
+        assertEquals(response.baseOffset(), expectedOffset);
     }
 
     private static MemoryRecords newIdempotentRecords(
@@ -1171,10 +1196,13 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
         final int minBytes = 1;
 
         @Cleanup
-        final KafkaHeaderAndRequest request = buildRequest(FetchRequest.Builder.forConsumer(maxWaitMs, minBytes,
-                Collections.singletonMap(topicPartition, new FetchRequest.PartitionData(
+        final KafkaHeaderAndRequest request = buildRequest(FetchRequest.Builder
+                .forConsumer(ApiKeys.FETCH.latestVersion(),
+                maxWaitMs, minBytes,
+                Collections.singletonMap(topicPartition, new FetchRequest.PartitionData(null,
                         0L, -1L, 1024 * 1024, Optional.empty()
                 ))));
+
         final CompletableFuture<AbstractResponse> future = new CompletableFuture<>();
         final long startTime = System.currentTimeMillis();
         kafkaRequestHandler.handleFetchRequest(request, future);
@@ -1186,11 +1214,10 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
         AbstractResponse abstractResponse = ((ResponseCallbackWrapper)
                 future.get(maxWaitMs + 1000, TimeUnit.MILLISECONDS)).getResponse();
         assertTrue(abstractResponse instanceof FetchResponse);
-        final FetchResponse<MemoryRecords> response = (FetchResponse<MemoryRecords>) abstractResponse;
+        final FetchResponse response = (FetchResponse) abstractResponse;
         assertEquals(response.error(), Errors.NONE);
         final long endTime = System.currentTimeMillis();
-        log.info("Take {} ms to process FETCH request, record count: {}",
-                endTime - startTime, response.responseData().size());
+        log.info("Take {} ms to process FETCH request", endTime - startTime);
         assertTrue(endTime - startTime <= maxWaitMs);
 
         Long waitingFetchesTriggered = kafkaRequestHandler.getRequestStats().getWaitingFetchesTriggered().get();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -1197,7 +1197,7 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
 
         @Cleanup
         final KafkaHeaderAndRequest request = buildRequest(FetchRequest.Builder
-                .forConsumer(ApiKeys.FETCH.latestVersion(),
+                .forConsumer(ApiKeys.FETCH.oldestVersion(),
                 maxWaitMs, minBytes,
                 Collections.singletonMap(topicPartition, new FetchRequest.PartitionData(null,
                         0L, -1L, 1024 * 1024, Optional.empty()

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaCommonTestUtils.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaCommonTestUtils.java
@@ -48,7 +48,7 @@ public class KafkaCommonTestUtils {
     public static FetchRequest.PartitionData newFetchRequestPartitionData(long fetchOffset,
                                                                           long logStartOffset,
                                                                           int maxBytes) {
-        return new FetchRequest.PartitionData(fetchOffset,
+        return new FetchRequest.PartitionData(null, fetchOffset,
                 logStartOffset,
                 maxBytes,
                 Optional.empty()

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaCommonTestUtils.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaCommonTestUtils.java
@@ -13,6 +13,8 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
+import static org.testng.Assert.assertEquals;
+
 import io.netty.buffer.ByteBuf;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
@@ -110,7 +112,12 @@ public class KafkaCommonTestUtils {
 
     public static KafkaCommandDecoder.KafkaHeaderAndRequest buildRequest(AbstractRequest.Builder builder,
                                                                   SocketAddress serviceAddress) {
-        AbstractRequest request = builder.build(builder.apiKey().latestVersion());
+        return buildRequest(builder, serviceAddress, builder.latestAllowedVersion());
+    }
+    public static KafkaCommandDecoder.KafkaHeaderAndRequest buildRequest(AbstractRequest.Builder builder,
+                SocketAddress serviceAddress, short version) {
+        AbstractRequest request = builder.build(version);
+        assertEquals(version, request.version());
         RequestHeader mockHeader = new RequestHeader(builder.apiKey(), request.version(), "dummy", 1233);
 
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerProxyTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerProxyTest.java
@@ -16,6 +16,7 @@ package io.streamnative.pulsar.handlers.kop;
 import lombok.extern.slf4j.Slf4j;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 /**
  * Unit test for {@link KafkaRequestHandler} but via Proxy.
@@ -39,5 +40,10 @@ public class KafkaRequestHandlerProxyTest extends KafkaRequestHandlerTest {
 
     protected int getClientPort() {
         return getKafkaProxyPort();
+    }
+
+    @Test(timeOut = 20000000)
+    public void testDescribeConsumerGroups() throws Exception {
+        super.testDescribeConsumerGroups();
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -756,7 +756,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
         final RequestHeader header =
                 new RequestHeader(ApiKeys.LIST_OFFSETS, ApiKeys.LIST_OFFSETS.latestVersion(), "client", 0);
         final ListOffsetsRequest request =
-                ListOffsetsRequest.Builder.forConsumer(true, IsolationLevel.READ_UNCOMMITTED)
+                ListOffsetsRequest.Builder.forConsumer(true, IsolationLevel.READ_UNCOMMITTED, false)
                         .setTargetTimes(KafkaCommonTestUtils
                                 .newListOffsetTargetTimes(topicPartition, ListOffsetsRequest.EARLIEST_TIMESTAMP))
                         .build(ApiKeys.LIST_OFFSETS.latestVersion());

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -938,6 +938,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
         ConsumerGroupDescription group2Description = consumerGroupDescriptionMap.get(group2);
         assertEquals(2, group2Description.members().size());
 
+        // KIP-709 https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=173084258
         ListConsumerGroupOffsetsResult listConsumerGroupOffsetsResult = kafkaAdmin.listConsumerGroupOffsets(Map.of(
                 group1, new ListConsumerGroupOffsetsSpec().topicPartitions(null),
                 group2, new ListConsumerGroupOffsetsSpec().topicPartitions(null))

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
@@ -539,11 +539,12 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
                     .flatMap(t -> t.partitions().stream())
                     .allMatch(d->d.errorCode() == Errors.TOPIC_AUTHORIZATION_FAILED.code()));
         } else {
-            assertEquals(offsetFetchResponse.error(), Errors.TOPIC_AUTHORIZATION_FAILED);
-            assertEquals(offsetFetchResponse.data()
+            assertTrue(offsetFetchResponse.data()
                     .topics()
                     .stream().flatMap(t -> t.partitions().stream())
-                    .count(), 1);
+                    .allMatch(d->d.errorCode() == Errors.TOPIC_AUTHORIZATION_FAILED.code()));
+
+            assertEquals(offsetFetchResponse.error(), Errors.NONE);
         }
 
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -342,11 +342,9 @@ public abstract class KopProtocolHandlerTestBase {
             createAdmin();
             createClient();
             MetadataUtils.createOffsetMetadataIfMissing(conf.getKafkaMetadataTenant(), admin, clusterData, this.conf);
-            triggerTopicLookup(MetadataUtils.constructOffsetsTopicBaseName(conf.getKafkaMetadataTenant(), conf));
 
             if (conf.isKafkaTransactionCoordinatorEnabled()) {
                 MetadataUtils.createTxnMetadataIfMissing(conf.getKafkaMetadataTenant(), admin, clusterData, this.conf);
-                    triggerTopicLookup(MetadataUtils.constructTxnLogTopicBaseName(conf.getKafkaMetadataTenant(), conf));
             }
 
             // we don't want user topic to use compaction

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -210,7 +210,8 @@ public abstract class KopProtocolHandlerTestBase {
         // kafka related settings.
         kafkaConfig.setOffsetsTopicNumPartitions(1);
 
-        kafkaConfig.setKafkaTransactionCoordinatorEnabled(false);
+        // kafka 3.1.x clients init the producerId by default, so we need to enable it.
+        kafkaConfig.setKafkaTransactionCoordinatorEnabled(true);
         kafkaConfig.setKafkaTxnLogTopicNumPartitions(1);
 
         kafkaConfig.setKafkaListeners(
@@ -341,9 +342,13 @@ public abstract class KopProtocolHandlerTestBase {
             createAdmin();
             createClient();
             MetadataUtils.createOffsetMetadataIfMissing(conf.getKafkaMetadataTenant(), admin, clusterData, this.conf);
+            triggerTopicLookup(MetadataUtils.constructOffsetsTopicBaseName(conf.getKafkaMetadataTenant(), conf));
+
             if (conf.isKafkaTransactionCoordinatorEnabled()) {
                 MetadataUtils.createTxnMetadataIfMissing(conf.getKafkaMetadataTenant(), admin, clusterData, this.conf);
+                    triggerTopicLookup(MetadataUtils.constructTxnLogTopicBaseName(conf.getKafkaMetadataTenant(), conf));
             }
+
             // we don't want user topic to use compaction
             admin.namespaces().removeCompactionThreshold(conf.getKafkaTenant() + "/" + conf.getKafkaNamespace());
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
@@ -125,7 +125,7 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase {
         }
 
         Assert.assertEquals(getApiKeysSet(), new TreeSet<>(
-                Arrays.asList(ApiKeys.API_VERSIONS, ApiKeys.METADATA, ApiKeys.PRODUCE)));
+                Arrays.asList(ApiKeys.API_VERSIONS, ApiKeys.METADATA, ApiKeys.PRODUCE, ApiKeys.INIT_PRODUCER_ID)));
 
         // 2. consume messages with Kafka consumer
         @Cleanup
@@ -152,14 +152,14 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase {
 
         Assert.assertEquals(getApiKeysSet(), new TreeSet<>(Arrays.asList(
                 ApiKeys.API_VERSIONS, ApiKeys.METADATA, ApiKeys.PRODUCE, ApiKeys.FIND_COORDINATOR, ApiKeys.LIST_OFFSETS,
-                ApiKeys.OFFSET_FETCH, ApiKeys.FETCH
+                ApiKeys.OFFSET_FETCH, ApiKeys.FETCH, ApiKeys.INIT_PRODUCER_ID
         )));
 
         // commit offsets
         kConsumer.getConsumer().commitSync(Duration.ofSeconds(5));
         Assert.assertEquals(getApiKeysSet(), new TreeSet<>(Arrays.asList(
                 ApiKeys.API_VERSIONS, ApiKeys.METADATA, ApiKeys.PRODUCE, ApiKeys.FIND_COORDINATOR, ApiKeys.LIST_OFFSETS,
-                ApiKeys.OFFSET_FETCH, ApiKeys.FETCH, ApiKeys.OFFSET_COMMIT
+                ApiKeys.OFFSET_FETCH, ApiKeys.FETCH, ApiKeys.OFFSET_COMMIT, ApiKeys.INIT_PRODUCER_ID
         )));
 
         try {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
@@ -63,8 +63,8 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.requests.FetchResponse;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -867,12 +867,12 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         partitionLog.awaitInitialisation().get();
         assertEquals(0, partitionLog.fetchOldestAvailableIndexFromTopic().get().longValue());
 
-        List<FetchResponse.AbortedTransaction> abortedIndexList =
+        List<FetchResponseData.AbortedTransaction> abortedIndexList =
                 partitionLog.getProducerStateManager().getAbortedIndexList(Long.MIN_VALUE);
         abortedIndexList.forEach(tx -> {
             log.info("TX {}", tx);
         });
-        assertEquals(0, abortedIndexList.get(0).firstOffset);
+        assertEquals(0, abortedIndexList.get(0).firstOffset());
 
         producer.beginTransaction();
         String lastMessage = "msg1b";
@@ -907,7 +907,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         abortedIndexList.forEach(tx -> {
             log.info("TX {}", tx);
         });
-        assertEquals(0, abortedIndexList.get(0).firstOffset);
+        assertEquals(0, abortedIndexList.get(0).firstOffset());
         assertEquals(1, abortedIndexList.size());
 
         waitForTransactionsToBeInStableState(transactionalId);
@@ -946,7 +946,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         });
 
         assertEquals(1, abortedIndexList.size());
-        assertEquals(0, abortedIndexList.get(0).firstOffset);
+        assertEquals(0, abortedIndexList.get(0).firstOffset());
 
         producer.beginTransaction();
         producer.send(new ProducerRecord<>(topicName, 0, "msg4")).get(); // OFFSET 8
@@ -973,8 +973,8 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
             log.info("TX {}", tx);
         });
 
-        assertEquals(0, abortedIndexList.get(0).firstOffset);
-        assertEquals(11, abortedIndexList.get(1).firstOffset);
+        assertEquals(0, abortedIndexList.get(0).firstOffset());
+        assertEquals(11, abortedIndexList.get(1).firstOffset());
         assertEquals(2, abortedIndexList.size());
 
         producer.beginTransaction();
@@ -999,8 +999,8 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
             log.info("TX {}", tx);
         });
 
-        assertEquals(0, abortedIndexList.get(0).firstOffset);
-        assertEquals(11, abortedIndexList.get(1).firstOffset);
+        assertEquals(0, abortedIndexList.get(0).firstOffset());
+        assertEquals(11, abortedIndexList.get(1).firstOffset());
         assertEquals(2, abortedIndexList.size());
 
 
@@ -1015,7 +1015,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
             log.info("TX {}", tx);
         });
         assertEquals(1, abortedIndexList.size());
-        assertEquals(11, abortedIndexList.get(0).firstOffset);
+        assertEquals(11, abortedIndexList.get(0).firstOffset());
 
         // use a new consumer group, it will read from the beginning of the topic
         assertEquals(
@@ -1448,12 +1448,12 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
                     .getPartitionLog(topicPartition, namespacePrefix);
             partitionLog.awaitInitialisation().get();
 
-            List<FetchResponse.AbortedTransaction> abortedIndexList =
+            List<FetchResponseData.AbortedTransaction> abortedIndexList =
                     partitionLog.getProducerStateManager().getAbortedIndexList(Long.MIN_VALUE);
             assertEquals(2, abortedIndexList.size());
             assertEquals(2, abortedIndexList.size());
-            assertEquals(0, abortedIndexList.get(0).firstOffset);
-            assertEquals(3, abortedIndexList.get(1).firstOffset);
+            assertEquals(0, abortedIndexList.get(0).firstOffset());
+            assertEquals(3, abortedIndexList.get(1).firstOffset());
 
             takeSnapshot(topicName);
 
@@ -1478,8 +1478,8 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
             abortedIndexList =
                     partitionLog.getProducerStateManager().getAbortedIndexList(Long.MIN_VALUE);
             assertEquals(2, abortedIndexList.size());
-            assertEquals(0, abortedIndexList.get(0).firstOffset);
-            assertEquals(3, abortedIndexList.get(1).firstOffset);
+            assertEquals(0, abortedIndexList.get(0).firstOffset());
+            assertEquals(3, abortedIndexList.get(1).firstOffset());
 
             // force reading the minimum valid offset
             // the timer is not started by the PH because
@@ -1498,7 +1498,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
             assertEquals(1, abortedIndexList.size());
             // the second TX cannot be purged because the lastOffset is 5, that is the boundary of the
             // trimmed portion of the topic
-            assertEquals(3, abortedIndexList.get(0).firstOffset);
+            assertEquals(3, abortedIndexList.get(0).firstOffset());
 
             producer1.close();
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/UpgradeTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/UpgradeTest.java
@@ -13,12 +13,19 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
+import io.streamnative.kafka.client.api.KafkaClientFactoryImpl;
+import io.streamnative.kafka.client.api.KafkaVersion;
+import io.streamnative.kafka.client.api.Producer;
+import io.streamnative.kafka.client.api.ProducerConfiguration;
+import io.streamnative.kafka.client.api.RecordMetadata;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.Cleanup;
@@ -28,8 +35,6 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
@@ -113,18 +118,23 @@ public class UpgradeTest extends KopProtocolHandlerTestBase {
 
     private List<Long> sendMessages(final String topic, final int start, final int end) throws Exception {
         final List<Long> offsets = Lists.newArrayList();
+        // use an old client the doesn't require transactions
+        KafkaClientFactoryImpl kafkaClientFactory = new KafkaClientFactoryImpl(KafkaVersion.KAFKA_2_8_0);
+        ProducerConfiguration producerConfiguration = ProducerConfiguration.builder()
+                .bootstrapServers("localhost:" + getClientPort())
+                .valueSerializer(org.apache.kafka280.common.serialization.StringSerializer.class.getName())
+                .keySerializer(org.apache.kafka280.common.serialization.StringSerializer.class.getName())
+                .build();
         @Cleanup
-        final KafkaProducer<String, String> producer = new KafkaProducer<>(newKafkaProducerProperties());
+        final Producer<String, String> producer = kafkaClientFactory.createProducer(producerConfiguration);
+        List<Future<RecordMetadata>> futures = new ArrayList<>();
         for (int i = start; i < end; i++) {
             final String value = "msg-" + i;
-            producer.send(new ProducerRecord<>(topic, value), (metadata, e) -> {
-                if (e == null) {
-                    offsets.add(metadata.offset());
-                    log.info("Send {} to {}-{}@{}", value, metadata.topic(), metadata.partition(), metadata.offset());
-                } else {
-                    log.error("Failed to send {} to {}: {}", value, topic, e.getMessage());
-                }
-            }).get();
+            futures.add(producer.sendAsync(producer.newContextBuilder(topic, value)
+                    .build()));
+        }
+        for (Future<RecordMetadata> future : futures) {
+            offsets.add(future.get().getOffset());
         }
         return offsets;
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManagerTest.java
@@ -106,6 +106,8 @@ public class TransactionStateManagerTest extends KopProtocolHandlerTestBase {
     @BeforeClass
     @Override
     protected void setup() throws Exception {
+        // we need to disable the kafka transaction coordinator to avoid the conflict
+        this.conf.setKafkaTransactionCoordinatorEnabled(false);
         this.conf.setKafkaTxnLogTopicNumPartitions(numPartitions);
         internalSetup();
         MetadataUtils.createTxnMetadataIfMissing(conf.getKafkaMetadataTenant(), admin, clusterData, this.conf);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/GlobalKTableTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/GlobalKTableTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.ForeachAction;
@@ -109,7 +110,8 @@ public class GlobalKTableTest extends KafkaStreamsTestBase {
         produceGlobalTableValues();
 
         final ReadOnlyKeyValueStore<Long, String> replicatedStore =
-                kafkaStreams.store(globalStore, QueryableStoreTypes.keyValueStore());
+                kafkaStreams.store(
+                        StoreQueryParameters.fromNameAndType(globalStore, QueryableStoreTypes.keyValueStore()));
 
         TestUtils.waitForCondition(() -> "J".equals(replicatedStore.get(5L)),
                 30000, "waiting for data in replicated store");
@@ -143,7 +145,9 @@ public class GlobalKTableTest extends KafkaStreamsTestBase {
         produceGlobalTableValues();
 
         final ReadOnlyKeyValueStore<Long, String> replicatedStore =
-                kafkaStreams.store(globalStore, QueryableStoreTypes.<Long, String>keyValueStore());
+                kafkaStreams.store(
+                        StoreQueryParameters
+                                .fromNameAndType(globalStore, QueryableStoreTypes.<Long, String>keyValueStore()));
 
         TestUtils.waitForCondition(() -> "J".equals(replicatedStore.get(5L)),
                 30000, "waiting for data in replicated store");
@@ -173,13 +177,15 @@ public class GlobalKTableTest extends KafkaStreamsTestBase {
         Thread.sleep(1000); // NOTE: it may take a few milliseconds to wait streams started
 
         ReadOnlyKeyValueStore<Long, String> store =
-                kafkaStreams.store(globalStore, QueryableStoreTypes.keyValueStore());
+                kafkaStreams.store(
+                        StoreQueryParameters.fromNameAndType(globalStore, QueryableStoreTypes.keyValueStore()));
         assertEquals(store.approximateNumEntries(), 4L);
         kafkaStreams.close();
 
         startStreams();
         Thread.sleep(1000); // NOTE: it may take a few milliseconds to wait streams started
-        store = kafkaStreams.store(globalStore, QueryableStoreTypes.keyValueStore());
+        store = kafkaStreams.store(
+                StoreQueryParameters.fromNameAndType(globalStore, QueryableStoreTypes.keyValueStore()));
         assertEquals(store.approximateNumEntries(), 4L);
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/KStreamAggregationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/KStreamAggregationTest.java
@@ -695,6 +695,9 @@ public class KStreamAggregationTest extends KafkaStreamsTestBase {
         consumerProperties.setProperty(StreamsConfig.WINDOW_SIZE_MS_CONFIG, Long.MAX_VALUE + "");
         if (keyDeserializer instanceof TimeWindowedDeserializer
                 || keyDeserializer instanceof SessionWindowedDeserializer) {
+            consumerProperties.setProperty(StreamsConfig.WINDOWED_INNER_CLASS_SERDE,
+                    Serdes.serdeFrom(innerClass).getClass().getName());
+
             consumerProperties.setProperty(StreamsConfig.DEFAULT_WINDOWED_KEY_SERDE_INNER_CLASS,
                     Serdes.serdeFrom(innerClass).getClass().getName());
         }
@@ -745,6 +748,8 @@ public class KStreamAggregationTest extends KafkaStreamsTestBase {
         final Map<String, String> configs = new HashMap<>();
         Serde<?> serde = Serdes.serdeFrom(innerClass);
         configs.put(StreamsConfig.DEFAULT_WINDOWED_KEY_SERDE_INNER_CLASS, serde.getClass().getName());
+        configs.put(StreamsConfig.WINDOWED_INNER_CLASS_SERDE, serde.getClass().getName());
+
         serde.close();
         // https://issues.apache.org/jira/browse/KAFKA-10366
         configs.put(StreamsConfig.WINDOW_SIZE_MS_CONFIG, Long.toString(Long.MAX_VALUE));

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/KStreamAggregationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/KStreamAggregationTest.java
@@ -48,9 +48,11 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Aggregator;
 import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.Initializer;
 import org.apache.kafka.streams.kstream.KGroupedStream;
 import org.apache.kafka.streams.kstream.KStream;
@@ -58,7 +60,6 @@ import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.Reducer;
-import org.apache.kafka.streams.kstream.Serialized;
 import org.apache.kafka.streams.kstream.SessionWindowedDeserializer;
 import org.apache.kafka.streams.kstream.SessionWindows;
 import org.apache.kafka.streams.kstream.TimeWindowedDeserializer;
@@ -115,7 +116,7 @@ public class KStreamAggregationTest extends KafkaStreamsTestBase {
         groupedStream = stream
                 .groupBy(
                         mapper,
-                        Serialized.with(Serdes.String(), Serdes.String()));
+                        Grouped.with(Serdes.String(), Serdes.String()));
 
         reducer = (value1, value2) -> value1 + ":" + value2;
         initializer = () -> 0;
@@ -174,7 +175,7 @@ public class KStreamAggregationTest extends KafkaStreamsTestBase {
 
         final Serde<Windowed<String>> windowedSerde = WindowedSerdes.timeWindowedSerdeFrom(String.class);
         groupedStream
-                .windowedBy(TimeWindows.of(500L))
+                .windowedBy(TimeWindows.of(Duration.ofMillis(500L)))
                 .reduce(reducer)
                 .toStream()
                 .to(outputTopic, Produced.with(windowedSerde, Serdes.String()));
@@ -279,7 +280,7 @@ public class KStreamAggregationTest extends KafkaStreamsTestBase {
         produceMessages(secondTimestamp);
 
         final Serde<Windowed<String>> windowedSerde = WindowedSerdes.timeWindowedSerdeFrom(String.class);
-        groupedStream.windowedBy(TimeWindows.of(500L))
+        groupedStream.windowedBy(TimeWindows.of(Duration.ofMillis(500L)))
                 .aggregate(
                         initializer,
                         aggregator,
@@ -415,8 +416,8 @@ public class KStreamAggregationTest extends KafkaStreamsTestBase {
         produceMessages(timestamp);
         produceMessages(timestamp);
 
-        stream.groupByKey(Serialized.with(Serdes.Integer(), Serdes.String()))
-                .windowedBy(TimeWindows.of(500L))
+        stream.groupByKey(Grouped.with(Serdes.Integer(), Serdes.String()))
+                .windowedBy(TimeWindows.of(Duration.ofMillis(500L)))
                 .count()
                 .toStream((windowedKey, value) -> windowedKey.key() + "@"
                         + windowedKey.window().start()).to(outputTopic, Produced.with(Serdes.String(), Serdes.Long()));
@@ -510,8 +511,9 @@ public class KStreamAggregationTest extends KafkaStreamsTestBase {
         final CountDownLatch latch = new CountDownLatch(11);
 
         builder.stream(userSessionsStream, Consumed.with(Serdes.String(), Serdes.String()))
-                .groupByKey(Serialized.with(Serdes.String(), Serdes.String()))
-                .windowedBy(SessionWindows.with(sessionGap).until(maintainMillis))
+                .groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
+                .windowedBy(SessionWindows.ofInactivityGapAndGrace(Duration.ofMillis(sessionGap),
+                        Duration.ofMillis(maintainMillis)))
                 .count()
                 .toStream()
                 .transform(() -> new Transformer<Windowed<String>, Long, KeyValue<Object, Object>>() {
@@ -609,8 +611,9 @@ public class KStreamAggregationTest extends KafkaStreamsTestBase {
         final CountDownLatch latch = new CountDownLatch(11);
         final String userSessionsStore = "UserSessionsStore";
         builder.stream(userSessionsStream, Consumed.with(Serdes.String(), Serdes.String()))
-                .groupByKey(Serialized.with(Serdes.String(), Serdes.String()))
-                .windowedBy(SessionWindows.with(sessionGap).until(maintainMillis))
+                .groupByKey(Grouped.with(Serdes.String(), Serdes.String()))
+                .windowedBy(SessionWindows.ofInactivityGapAndGrace(Duration.ofMillis(sessionGap),
+                        Duration.ofMillis(maintainMillis)))
                 .reduce((value1, value2) -> value1 + ":" + value2, Materialized.as(userSessionsStore))
                 .toStream()
                 .foreach((key, value) -> {
@@ -621,7 +624,8 @@ public class KStreamAggregationTest extends KafkaStreamsTestBase {
         startStreams();
         latch.await(30, TimeUnit.SECONDS);
         final ReadOnlySessionStore<String, String> sessionStore =
-                kafkaStreams.store(userSessionsStore, QueryableStoreTypes.sessionStore());
+                kafkaStreams.store(
+                        StoreQueryParameters.fromNameAndType(userSessionsStore, QueryableStoreTypes.sessionStore()));
 
         // verify correct data received
         assertThat(results.get(new Windowed<>("bob", new SessionWindow(t1, t1))), equalTo("start"));

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/KTableTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/KTableTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.kstream.Consumed;
@@ -115,14 +116,16 @@ public class KTableTest extends KafkaStreamsTestBase {
         startStreams();
         Thread.sleep(1000); // NOTE: it may take a few milliseconds to wait streams started
         final ReadOnlyKeyValueStore<Long, String> store =
-                kafkaStreams.store(this.store, QueryableStoreTypes.keyValueStore());
+                kafkaStreams.store(
+                        StoreQueryParameters.fromNameAndType(this.store, QueryableStoreTypes.keyValueStore()));
         TestUtils.waitForCondition(() -> store.approximateNumEntries() == 4L, 30000L, "waiting for values");
         kafkaStreams.close();
 
         startStreams();
         Thread.sleep(1000); // NOTE: it may take a few milliseconds to wait streams started
         final ReadOnlyKeyValueStore<Long, String> recoveredStore =
-                kafkaStreams.store(this.store, QueryableStoreTypes.keyValueStore());
+                kafkaStreams.store(
+                        StoreQueryParameters.fromNameAndType(this.store, QueryableStoreTypes.keyValueStore()));
         TestUtils.waitForCondition(() -> {
                          try {
                              return recoveredStore.approximateNumEntries() == 4L;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/KafkaStreamsTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/KafkaStreamsTestBase.java
@@ -15,8 +15,8 @@ package io.streamnative.pulsar.handlers.kop.streams;
 
 import io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase;
 import io.streamnative.pulsar.handlers.kop.utils.timer.MockTime;
+import java.time.Duration;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 import lombok.Getter;
 import lombok.NonNull;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -83,7 +83,7 @@ public abstract class KafkaStreamsTestBase extends KopProtocolHandlerTestBase {
     @AfterMethod
     protected void cleanupTestCase() throws Exception {
         if (kafkaStreams != null) {
-            kafkaStreams.close(3, TimeUnit.SECONDS);
+            kafkaStreams.close(Duration.ofSeconds(3));
             TestUtils.purgeLocalStreamsState(streamsConfiguration);
         }
     }

--- a/tests/src/test/resources/log4j2.xml
+++ b/tests/src/test/resources/log4j2.xml
@@ -43,6 +43,6 @@
         <Logger name="io.streamnative" level="debug"/>
         <Logger name="org.apache.pulsar" level="info"/>
         <Logger name="org.apache.bookkeeper" level="info"/>
-        <Logger name="org.apache.kafka" level="info"/>
+        <Logger name="org.apache.kafka" level="debug"/>
     </Loggers>
 </Configuration>

--- a/tests/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/tests/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Contents:
- upgrade the Kafka client library to 3.4.0
- Enable the TransactionCoordinator by default in all the tests, because the Producer always calls INIT_PRODUCER_ID
- This is a prerequisite to implement https://cwiki.apache.org/confluence/display/KAFKA/KIP-664%3A+Provide+tooling+to+detect+and+abort+hanging+transactions
- Implement KIP-699 https://cwiki.apache.org/confluence/display/KAFKA/KIP-699%3A+Update+FindCoordinator+to+resolve+multiple+Coordinators+at+a+time
- Implement KIP-709 https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=173084258 

Notable changes:
- FetchResponse: PartitionData is now grouped by topic and not by TopicPartition
- FetchRequest.  .> createFetchRequest in KafkaApisTest - test multiple versions
- FindCoordinatorRequest/Response version > 3 - supports multiple groups
- OffsetFetchRequest/Response version 8 - supports multiple groups
- Minor updates to KStreams tests
- Allow Transaction Recovery to not break in case of legacy entries without Index metadata

Other minor changes:
- ListOffsetsRequest.Builder: changed forConsumer(true, IsolationLevel.READ_UNCOMMITTED) to forConsumer(true, IsolationLevel.READ_UNCOMMITTED, false)
- TxnOffsetCommitRequest.Builder("1", group, 1, (short) 1, offsetData, false /*removed*/ );


