### PR TITLE
[transactions] KIP-664 Implement abortTransaction from KafkaAdmin (proxy)

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -1202,7 +1202,8 @@ public class PartitionLog {
                     .setProducerId(producerStateEntry.producerId())
                     .setLastSequence(-1) // NOT HANDLED YET
                     .setProducerEpoch(producerStateEntry.producerEpoch() != null
-                            ? producerStateEntry.producerEpoch().intValue() : -1)
+                            && producerStateEntry.producerEpoch() >= 0
+                            ? producerStateEntry.producerEpoch().intValue() : 0)
                     .setLastTimestamp(producerStateEntry.lastTimestamp() != null
                             ? producerStateEntry.lastTimestamp().longValue() : -1)
                     .setCoordinatorEpoch(producerStateEntry.coordinatorEpoch())


### PR DESCRIPTION
This PR adds a test about the KafkaAdmin abortTransactions and implements the support for it on the Proxy

See more here
https://cwiki.apache.org/confluence/display/KAFKA/KIP-664%3A+Provide+tooling+to+detect+and+abort+hanging+transactions#KIP664:Providetoolingtodetectandaborthangingtransactions-AbortingTransactions

The test reproduces the behaviour of Kafka 3.4.0.

1) Start a transaction
2) Use KafkaAdmin#abortTransaction
3) The Admin tool sends a TxMarker to the Partition leader
4) The client is still able to commit the transaction because the Coordinator is not aware of the marker

Please note that when the Client (KafkaProducer) calls `commitTransaction` the Coordinator doesn't wait for the markers to be sent to the brokers, so it is not possible to let `commitTransaction` fail.