### PR TITLE
[proxy] Fix ProduceRequest doesn't pass timeoutMs

### DIFF
--- a/proxy/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProxyRequestHandler.java
+++ b/proxy/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProxyRequestHandler.java
@@ -630,7 +630,11 @@ public class KafkaProxyRequestHandler extends KafkaCommandDecoder {
                 Node kopBroker = topicMetadata.node;
 
                 ProduceRequestData produceRequestPerBroker = requestsPerBroker.computeIfAbsent(kopBroker,
-                        a -> new ProduceRequestData());
+                        a -> new ProduceRequestData()
+                                .setTimeoutMs(data.timeoutMs())
+                                .setAcks(data.acks())
+                                .setTransactionalId(data.transactionalId()));
+
                 ProduceRequestData.TopicProduceData topicProduceData = produceRequestPerBroker
                         .topicData()
                         .stream().filter(topic -> topic.name().equals(topicPartition.topic()))

--- a/proxy/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProxyRequestHandler.java
+++ b/proxy/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProxyRequestHandler.java
@@ -917,6 +917,9 @@ public class KafkaProxyRequestHandler extends KafkaCommandDecoder {
                                                 ((FetchRequest) fetch.getRequest()).maxWait(),
                                                 ((FetchRequest) fetch.getRequest()).minBytes(),
                                                 partitionDataMap)
+                                        .isolationLevel(fetchRequest.isolationLevel())
+                                        .metadata(fetchRequest.metadata())
+                                        .rackId(fetchRequest.rackId())
                                         .build();
                                 ByteBuf buffer = KopResponseUtils.serializeRequest(header, requestForSingleBroker);
                                 KafkaHeaderAndRequest singlePartitionRequest = new KafkaHeaderAndRequest(


### PR DESCRIPTION
Motivation:
When the proxy splits a Produce Request it doesn't  set timeoutMs (and other fields).

The effect is that on the broker the PRODUCE_REQUESTS are executing with timeout=0 and they fail most of the times

Changes:
- fix ProduceRequest (timeoutMs and transactionalId fields, that are very important)
- fix FetchRequest (useless fields)