### PR TITLE
Fix usage of Pulsar's AuthenticationState object

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
@@ -106,8 +106,10 @@ public class SchemaRegistryManager {
                 throw new SchemaStorageException("Pulsar is not configured for Token auth");
             }
             try {
+                AuthData authData = AuthData.of(password.getBytes(StandardCharsets.UTF_8));
                 final AuthenticationState authState = authenticationProvider
-                        .newAuthState(AuthData.of(password.getBytes(StandardCharsets.UTF_8)), null, null);
+                        .newAuthState(authData, null, null);
+                authState.authenticate(authData);
                 final String role = authState.getAuthRole();
 
                 final String tenant;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServer.java
@@ -79,8 +79,9 @@ public class PlainSaslServer implements SaslServer {
         }
 
         try {
-            final AuthenticationState authState = authenticationProvider.newAuthState(
-                    AuthData.of(saslAuth.getAuthData().getBytes(StandardCharsets.UTF_8)), null, null);
+            final AuthData authData = AuthData.of(saslAuth.getAuthData().getBytes(StandardCharsets.UTF_8));
+            final AuthenticationState authState = authenticationProvider.newAuthState(authData, null, null);
+            authState.authenticate(authData);
             final String role = authState.getAuthRole();
             if (StringUtils.isEmpty(role)) {
                 throw new AuthenticationException("Role cannot be empty.");

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthValidatorCallbackHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthValidatorCallbackHandler.java
@@ -126,8 +126,10 @@ public class OauthValidatorCallbackHandler implements AuthenticateCallbackHandle
         final String tenant = tokenAndTenant.getRight();
 
         try {
+            AuthData authData = AuthData.of(token.getBytes(StandardCharsets.UTF_8));
             final AuthenticationState authState = authenticationProvider.newAuthState(
-                    AuthData.of(token.getBytes(StandardCharsets.UTF_8)), null, null);
+                    authData, null, null);
+            authState.authenticate(authData);
             final String role = authState.getAuthRole();
             AuthenticationDataSource authDataSource = authState.getAuthDataSource();
             callback.token(new KopOAuthBearerToken() {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthValidatorCallbackHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthValidatorCallbackHandlerTest.java
@@ -47,6 +47,8 @@ public class OauthValidatorCallbackHandlerTest {
 
         doReturn(state).when(mockAuthProvider).newAuthState(any(), any(), any());
 
+        doReturn(null).when(state).authenticate(any());
+
         KopOAuthBearerValidatorCallback callbackWithTenant =
                 new KopOAuthBearerValidatorCallback("my-tenant" + OAuthTokenDecoder.DELIMITER + "my-token");
 


### PR DESCRIPTION
https://github.com/datastax/starlight-for-kafka/pull/84 relies on unreleased API changes. In order to fix the plugin for now, we need to first change to call `authenticate`. Then when the luna streaming release containing the asynchronous authentication changes gets released, we will upgrade S4K via #84.

For context on the breaking change, see https://github.com/apache/pulsar/pull/19295#discussion_r1126503217.