### PR TITLE
[fix][transaction] The delta time should less than aborted txn index purge interval

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
@@ -168,7 +168,7 @@ public class ProducerStateManager {
             log.debug("maybePurgeAbortedTx deltaFromLast {} vs kafkaTxnPurgeAbortedTxnIntervalSeconds {} ",
                     deltaFromLast, kafkaTxnPurgeAbortedTxnIntervalSeconds);
         }
-        if (deltaFromLast > kafkaTxnPurgeAbortedTxnIntervalSeconds) {
+        if (deltaFromLast < kafkaTxnPurgeAbortedTxnIntervalSeconds) {
             return 0;
         }
         lastPurgeAbortedTxnTime = now;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
@@ -34,7 +34,6 @@ import io.streamnative.pulsar.handlers.kop.storage.CompletedTxn;
 import io.streamnative.pulsar.handlers.kop.storage.PartitionLog;
 import io.streamnative.pulsar.handlers.kop.storage.ProducerStateManager;
 import io.streamnative.pulsar.handlers.kop.storage.ProducerStateManagerSnapshot;
-import io.streamnative.pulsar.handlers.kop.storage.ProducerStateManagerSnapshotBuffer;
 import io.streamnative.pulsar.handlers.kop.storage.TxnMetadata;
 import java.lang.reflect.Method;
 import java.time.Duration;
@@ -85,7 +84,6 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.pulsar.common.naming.TopicName;
 import org.awaitility.Awaitility;
-import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -1042,7 +1040,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
     }
 
     @Test(timeOut = 10_000)
-    public void testAbortedPurgeIntervalConfiguration() throws Exception {
+    public void testAbortedTxnIndexPurgeIntervalConfiguration() throws Exception {
         Class<ProducerStateManager> clazz = ProducerStateManager.class;
         Method maybePurgeMethod = clazz.getDeclaredMethod("maybePurgeAbortedTx");
         maybePurgeMethod.setAccessible(true);
@@ -1069,7 +1067,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         ProducerStateManager producerStateManager = new ProducerStateManager(
                 "aborted-txn-index-purge-interval-test-" + RandomStringUtils.randomAlphanumeric(5),
                 UUID.randomUUID().toString(),
-                Mockito.mock(ProducerStateManagerSnapshotBuffer.class),
+                null,
                 1000 * 30,
                 purgeAbortedTxnIntervalSec);
         producerStateManager.updateMapEndOffset(100L);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
@@ -16,10 +16,6 @@ package io.streamnative.pulsar.handlers.kop;
 import static org.apache.kafka.clients.CommonClientConfigs.CLIENT_ID_CONFIG;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -40,8 +36,6 @@ import io.streamnative.pulsar.handlers.kop.storage.ProducerStateManager;
 import io.streamnative.pulsar.handlers.kop.storage.ProducerStateManagerSnapshot;
 import io.streamnative.pulsar.handlers.kop.storage.ProducerStateManagerSnapshotBuffer;
 import io.streamnative.pulsar.handlers.kop.storage.TxnMetadata;
-
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -61,8 +55,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
-
-import io.streamnative.pulsar.handlers.kop.utils.ReflectionUtils;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;


### PR DESCRIPTION
### Modification

The delta time should be less than the aborted transaction index purge interval configuration.
Add a related unit test.