### PR TITLE
deps: Fixes for CVE-2023-39410, CVE-2022-1471 & CVE-2023-5072

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <spotbugs-annotations.version>3.1.12</spotbugs-annotations.version>
     <apicurio.version>2.1.3.Final</apicurio.version>
     <testng.version>6.14.3</testng.version>
-    <avro.version>1.10.2</avro.version>
+    <avro.version>1.11.3</avro.version>
     <awaitility.version>4.0.3</awaitility.version>
     <okhttp3.version>4.9.3</okhttp3.version>
     <gson.version>2.8.9</gson.version>
@@ -66,7 +66,7 @@
     <protobuf3.version>3.19.6</protobuf3.version>
     <junit.version>4.13.1</junit.version>
     <fusionauth-jwt.version>5.2.1</fusionauth-jwt.version>
-    <snakeyaml.version>1.32</snakeyaml.version>
+    <snakeyaml.version>2.0</snakeyaml.version>
     <zstd-jni.version>1.5.2-4</zstd-jni.version>
 
     <!-- plugin dependencies -->
@@ -83,7 +83,7 @@
     <kaml.version>0.53.0</kaml.version>
     <kotlinx-serialization-core.version>1.5.0</kotlinx-serialization-core.version>
     <kotlin.version>1.8.10</kotlin.version>
-    <org-json.version>20230227</org-json.version>
+    <org-json.version>20231013</org-json.version>
   </properties>
 
   <licenses>


### PR DESCRIPTION
Fixes:
- avro: from 1.10.2 to 1.11.3
   - Fixes CVE-2023-39410 
   - http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-39410
 
- snakeyaml: from 1.32 to 2.0
   - Fixes CVE-2022-1471
   - http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-1471

- json: from 20230227 to 20231013
   - Fixes CVE-2023-5072 
   - http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-5072