### PR TITLE
Use retry-able error codes for fetch failures (FETCH_SESSION_ID_NOT_FOUND instead of UNKNOWN_SERVER_ERROR)

### DIFF
--- a/proxy/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProxyRequestHandler.java
+++ b/proxy/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProxyRequestHandler.java
@@ -964,7 +964,8 @@ public class KafkaProxyRequestHandler extends KafkaCommandDecoder {
                                             log.error("bad error while fetching for {} from {}",
                                                     fetchData.keySet(), badError, kopBroker);
                                             fetchData.keySet().forEach(topicPartition ->
-                                                    errorsConsumer.accept(topicPartition, Errors.FETCH_SESSION_TOPIC_ID_ERROR)
+                                                    errorsConsumer.accept(topicPartition,
+                                                        Errors.FETCH_SESSION_TOPIC_ID_ERROR)
                                             );
                                             return null;
                                         }).whenComplete((ignore1, ignore2) -> {

--- a/proxy/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProxyRequestHandler.java
+++ b/proxy/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProxyRequestHandler.java
@@ -823,7 +823,7 @@ public class KafkaProxyRequestHandler extends KafkaCommandDecoder {
                                     }).exceptionally(badError -> {
                                         log.error("bad error for FULL fetch", badError);
                                         FetchResponse fetchResponse = buildFetchErrorResponse(fetchRequest,
-                                                fetchData, Errors.FETCH_SESSION_TOPIC_ID_ERROR);
+                                                fetchData, Errors.KAFKA_STORAGE_ERROR);
                                         resultFuture.complete(fetchResponse);
                                         return null;
                                     });
@@ -965,7 +965,7 @@ public class KafkaProxyRequestHandler extends KafkaCommandDecoder {
                                                     fetchData.keySet(), badError, kopBroker);
                                             fetchData.keySet().forEach(topicPartition ->
                                                     errorsConsumer.accept(topicPartition,
-                                                        Errors.FETCH_SESSION_TOPIC_ID_ERROR)
+                                                        Errors.KAFKA_STORAGE_ERROR)
                                             );
                                             return null;
                                         }).whenComplete((ignore1, ignore2) -> {


### PR DESCRIPTION
With the proxy configuration, restarting the broker triggers SERVER_UNKNOWN_ERROR that is not a retry-able error. This behaves differently than the Kafka broker restarts. In order to retry, update some errors codes to retry-able FETCH error codes.

Error codes' retry-able column is described at https://kafka.apache.org/protocol#protocol_error_codes