### PR TITLE
Upgrade Avro to 1.11.4 to address CVE-2024-47561 in 2.10_ds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <spotbugs-annotations.version>3.1.12</spotbugs-annotations.version>
     <apicurio.version>2.1.3.Final</apicurio.version>
     <testng.version>6.14.3</testng.version>
-    <avro.version>1.10.2</avro.version>
+    <avro.version>1.11.4</avro.version>
     <awaitility.version>4.0.3</awaitility.version>
     <okhttp3.version>4.9.3</okhttp3.version>
     <gson.version>2.8.9</gson.version>


### PR DESCRIPTION
### Motivation

Avro 1.11.3 contains critical 9.3/10 level RCE vulnerability in Avro Java SDK <1.11.4, [CVE-2024-47561](https://github.com/advisories/GHSA-r7pg-v2c8-mfg3)>