### PR TITLE
Upgrade protobuf3 to 3.25.5 to address CVE-2024-7254

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <gson.version>2.8.9</gson.version>
     <commons-compress.version>1.21</commons-compress.version>
     <grpc.version>1.45.1</grpc.version>
-    <protobuf3.version>3.19.6</protobuf3.version>
+    <protobuf3.version>3.25.5</protobuf3.version>
     <junit.version>4.13.1</junit.version>
     <fusionauth-jwt.version>5.2.1</fusionauth-jwt.version>
     <snakeyaml.version>2.0</snakeyaml.version>


### PR DESCRIPTION
### Motivation

protobuf3 3.19.6 contains CVE-2024-7254 vulnerability and its fixed in 3.25.5.