### PR TITLE
Update dependencies to fix CVE-2024-7254, CVE-2024-36114 & CVE-2024-53990

### DIFF
--- a/ci/init_hydra_oauth_server.sh
+++ b/ci/init_hydra_oauth_server.sh
@@ -33,7 +33,7 @@ wait_for_url() {
 }
 
 # Start hydra server
-docker-compose -f ci/hydra/docker-compose.yml up -d
+docker compose -f ci/hydra/docker-compose.yml up -d
 
 # Wait until the hydra server started
 wait_for_url "http://localhost:4445/clients" "Waiting for Hydra admin REST to start"

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,9 @@
     <fusionauth-jwt.version>5.2.1</fusionauth-jwt.version>
     <snakeyaml.version>2.0</snakeyaml.version>
     <zstd-jni.version>1.5.2-4</zstd-jni.version>
-
+    <asynchttpclient.version>2.12.4</asynchttpclient.version>
+    <aircompressor.version>0.27</aircompressor.version>
+    <protobuf.version>3.25.5</protobuf.version>
     <!-- plugin dependencies -->
     <license-maven-plugin.version>3.0.rc1</license-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
@@ -126,7 +128,21 @@
         <artifactId>kafka-clients</artifactId>
         <version>${kafka.version}</version>
       </dependency>
-
+      <dependency>
+        <groupId>io.airlift</groupId>
+        <artifactId>aircompressor</artifactId>
+        <version>${aircompressor.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${protobuf.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.asynchttpclient</groupId>
+        <artifactId>async-http-client</artifactId>
+        <version>${asynchttpclient.version}</version>
+      </dependency>
       <dependency>
         <groupId>${pulsar.group.id}</groupId>
         <artifactId>pulsar-broker</artifactId>
@@ -135,6 +151,10 @@
           <exclusion>
             <groupId>io.grpc</groupId>
             <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -128,20 +128,26 @@
         <artifactId>kafka-clients</artifactId>
         <version>${kafka.version}</version>
       </dependency>
+      <!-- Override transitive dependency version to fix vulnerability -->
       <dependency>
         <groupId>io.airlift</groupId>
         <artifactId>aircompressor</artifactId>
         <version>${aircompressor.version}</version>
+        <scope>runtime</scope>
       </dependency>
+      <!-- Override transitive dependency version to fix vulnerability -->
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
         <version>${protobuf.version}</version>
+        <scope>runtime</scope>
       </dependency>
+      <!-- Override transitive dependency version to fix vulnerability -->
       <dependency>
         <groupId>org.asynchttpclient</groupId>
         <artifactId>async-http-client</artifactId>
         <version>${asynchttpclient.version}</version>
+        <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>${pulsar.group.id}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -140,14 +140,12 @@
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
         <version>${protobuf.version}</version>
-        <scope>runtime</scope>
       </dependency>
       <!-- Override transitive dependency version to fix vulnerability -->
       <dependency>
         <groupId>org.asynchttpclient</groupId>
         <artifactId>async-http-client</artifactId>
         <version>${asynchttpclient.version}</version>
-        <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>${pulsar.group.id}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -156,10 +156,6 @@
             <groupId>io.grpc</groupId>
             <artifactId>*</artifactId>
           </exclusion>
-          <exclusion>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java-util</artifactId>
-          </exclusion>
         </exclusions>
       </dependency>
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/docker/DockerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/docker/DockerTest.java
@@ -30,8 +30,8 @@ public class DockerTest {
 
     private static final String IMAGE_LUNASTREAMING31 = "datastax/lunastreaming:3.1";
     private static final String IMAGE_PULSAR31 = "apachepulsar/pulsar:3.1.1";
-    private static final String CONFLUENT_CLIENT = "confluentinc/cp-kafka:latest";
-    private static final String CONFLUENT_SCHEMAREGISTRY_CLIENT = "confluentinc/cp-schema-registry:latest";
+    private static final String CONFLUENT_CLIENT = "confluentinc/cp-kafka:7.8.2";
+    private static final String CONFLUENT_SCHEMAREGISTRY_CLIENT = "confluentinc/cp-schema-registry:7.8.2";
 
     @Test
     public void test() throws Exception {


### PR DESCRIPTION
asynchttpclient 2.12.1 contains CVE-2024-53990 vulnerability and its fixed in 2.12.4.
aircompressor 0.21 contains CVE-2024-36114 vulnerability and its fixed in 0.27
protobuf-java 3.19.6 contains CVE-2024-7254 vulnerability and its fixed in contains 3.25.5