### PR TITLE
Fix DockerTests and add the missing tlsProvider config parameter

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ssl/SSLUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ssl/SSLUtils.java
@@ -363,6 +363,7 @@ public class SSLUtils {
 
     public static PulsarSslConfiguration buildSslConfiguration(KafkaServiceConfiguration serviceConfig) {
         return PulsarSslConfiguration.builder()
+                .tlsProvider(serviceConfig.getTlsProvider())
                 .tlsKeyStoreType(serviceConfig.getTlsKeyStoreType())
                 .tlsKeyStorePath(serviceConfig.getTlsKeyStore())
                 .tlsKeyStorePassword(serviceConfig.getTlsKeyStorePassword())

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/docker/DockerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/docker/DockerTest.java
@@ -30,8 +30,8 @@ public class DockerTest {
 
     private static final String IMAGE_LUNASTREAMING40 = "datastax/lunastreaming:4.0_3.2";
     private static final String IMAGE_PULSAR40 = "apachepulsar/pulsar:4.0.4";
-    private static final String CONFLUENT_CLIENT = "confluentinc/cp-kafka:latest";
-    private static final String CONFLUENT_SCHEMAREGISTRY_CLIENT = "confluentinc/cp-schema-registry:latest";
+    private static final String CONFLUENT_CLIENT = "confluentinc/cp-kafka:7.8.2";
+    private static final String CONFLUENT_SCHEMAREGISTRY_CLIENT = "confluentinc/cp-schema-registry:7.8.2";
 
     @Test
     public void test() throws Exception {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/docker/PulsarContainer.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/docker/PulsarContainer.java
@@ -251,6 +251,7 @@ public class PulsarContainer implements AutoCloseable {
             // it is valid to set this URLS even if the broker does not enable TLS
             proxyContainer.withEnv("PULSAR_PREFIX_brokerServiceURLTLS", "pulsar+ssl://pulsar:6651");
             proxyContainer.withEnv("PULSAR_PREFIX_brokerWebServiceURLTLS", "https://pulsar:8443");
+            proxyContainer.withEnv("PULSAR_PREFIX_clusterName", "standalone");
 
             if (enableTls) {
                 proxyContainer.withEnv("PULSAR_PREFIX_kopSchemaRegistryProxyEnableTls", "true");


### PR DESCRIPTION
### Change Made
- DockerTests fail on the latest confluent kafka. So using the previous image instead of latest.
- Proxy in 4.0 requires `clusterName` to be specified for starting the container. Updated `PulsarContainer.java`.
- Added `tlsProvider` while building the  PulsarServiceConfiguration  kafka configuration.