### PR TITLE
Delegating SSLContext validation to DefaultPulsarSslFactory

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ssl/SSLUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ssl/SSLUtils.java
@@ -19,7 +19,6 @@ import static io.streamnative.pulsar.handlers.kop.KafkaProtocolHandler.TLS_HANDL
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import java.util.Arrays;
@@ -423,11 +422,8 @@ public class SSLUtils {
                     ch.pipeline().addLast(TLS_HANDLER, new SslHandler(createSslEngine(sslContextFactory)));
                 } else {
                     sslFactory.createInternalSslContext();
-                    SslContext sslContext = sslFactory.getInternalNettySslContext();
-                    if (sslContext != null) {
-                        ch.pipeline().addLast(TLS_HANDLER,
-                                new SslHandler(this.sslFactory.createServerSslEngine(ch.alloc())));
-                    }
+                    ch.pipeline().addLast(TLS_HANDLER,
+                            new SslHandler(this.sslFactory.createServerSslEngine(ch.alloc())));
                 }
             } catch (Exception err) {
                 throw new RuntimeException(err);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MessagePublishThrottlingTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MessagePublishThrottlingTest.java
@@ -81,7 +81,7 @@ public class MessagePublishThrottlingTest extends KopProtocolHandlerTestBase {
     private void waitForPublishRateChange(PersistentTopic topic, PublishRate expectedRate) throws Exception {
         // got to read private field, otherwise inaccessible
         Field throttleField = FieldUtils.getDeclaredField(AbstractTopic.class, "topicPublishRateLimiter", true);
-        PublishRateLimiterImpl throttle = (PublishRateLimiterImpl)FieldUtils.readField(throttleField, topic, true);
+        PublishRateLimiterImpl throttle = (PublishRateLimiterImpl) FieldUtils.readField(throttleField, topic, true);
 
         Awaitility.await().untilAsserted(() -> {
             if (expectedRate.publishThrottlingRateInMsg > 0) {


### PR DESCRIPTION
- https://github.com/datastax/starlight-for-kafka/pull/105 brought in validation logic that checks if the SSLContext is initialised. The validation is wrong. The exception thrown here is causing the channel to be closed in `ChannelInitializer`.
- To fix the issue, we are removing the validation logic in SSLUtils.java and depending on [DefaultPulsarSslFactory](https://github.com/datastax/pulsar/blob/3661572026c557a260b0779566ec02f48d3f2430/pulsar-common/src/main/java/org/apache/pulsar/common/util/DefaultPulsarSslFactory.java#L347) for validation.