### PR TITLE
[4.0] [Cherry-Pick] Set loadBalancerOverrideBrokerNicSpeedGbps for integration tests to fix jenkins

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -103,6 +103,7 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
             protocolHandlerDir
         );
         kConfig.setMessagingProtocols(Sets.newHashSet("kafka"));
+        kConfig.setLoadBalancerOverrideBrokerNicSpeedGbps(Optional.of(1.0d));
 
         return kConfig;
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/InnerTopicProtectionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/InnerTopicProtectionTest.java
@@ -70,6 +70,7 @@ public class InnerTopicProtectionTest extends KopProtocolHandlerTestBase {
             protocolHandlerDir
         );
         kConfig.setMessagingProtocols(Sets.newHashSet("kafka"));
+        kConfig.setLoadBalancerOverrideBrokerNicSpeedGbps(Optional.of(1.0d));
 
         return kConfig;
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -234,6 +234,7 @@ public abstract class KopProtocolHandlerTestBase {
                 protocolHandlerDir
         );
         kafkaConfig.setMessagingProtocols(Sets.newHashSet("kafka"));
+        kafkaConfig.setLoadBalancerOverrideBrokerNicSpeedGbps(Optional.of(1.0d));
 
         this.conf = kafkaConfig;
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetadataInitTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetadataInitTest.java
@@ -146,6 +146,7 @@ public class MetadataInitTest extends KopProtocolHandlerTestBase {
         conf.setProtocolHandlerDirectory(protocolHandlerDirectory);
         conf.setMessagingProtocols(Collections.singleton("kafka"));
         conf.setKafkaListeners(PLAINTEXT_PREFIX + "localhost:" + kafkaPort);
+        conf.setLoadBalancerOverrideBrokerNicSpeedGbps(Optional.of(1.0d));
         return conf;
     }
 


### PR DESCRIPTION
This is a cherry-pick PR of https://github.com/datastax/starlight-for-kafka/pull/110