### PR TITLE
Add commons dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -438,6 +438,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>${commons-compress.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
       <version>${log4j2.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <okhttp3.version>4.9.3</okhttp3.version>
     <gson.version>2.8.9</gson.version>
     <commons-compress.version>1.21</commons-compress.version>
+    <commons-configuration.version>1.10</commons-configuration.version>
     <grpc.version>1.45.1</grpc.version>
     <protobuf3.version>3.19.6</protobuf3.version>
     <junit.version>4.13.1</junit.version>
@@ -307,6 +308,11 @@
         <version>${commons-compress.version}</version>
       </dependency>
       <dependency>
+        <groupId>commons-configuration</groupId>
+        <artifactId>commons-configuration</artifactId>
+        <version>${commons-configuration.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.fusionauth</groupId>
         <artifactId>fusionauth-jwt</artifactId>
         <version>${fusionauth-jwt.version}</version>
@@ -438,9 +444,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-compress</artifactId>
-      <version>${commons-compress.version}</version>
+      <groupId>commons-configuration</groupId>
+      <artifactId>commons-configuration</artifactId>
+      <version>${commons-configuration.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -447,7 +447,6 @@
       <groupId>commons-configuration</groupId>
       <artifactId>commons-configuration</artifactId>
       <version>${commons-configuration.version}</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
**Motivation**

The transitive dependency `commons-configuration:commons-configuration` was previously included in `org.apache.pulsar`, and indirectly used here. However, this dependency has since been removed from Pulsar with the [change](https://github.com/apache/pulsar/pull/24562/commits/46025b5af27c542c37f0db8edbfbfbad57a90b20), resulting in missing runtime classes for components that rely on `commons-configuration`.

**Fix**

To address this, the dependency on commons-configuration is now being explicitly added to the pom of this project. This ensures continued functionality and avoids any runtime issues caused by the missing library.