### PR TITLE
CVE fixes - commons-lang3, commons-compress, jackson.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <commons-compress.version>1.21</commons-compress.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <grpc.version>1.45.1</grpc.version>
-    <protobuf3.version>3.19.6</protobuf3.version>
+    <protobuf3.version>3.25.5</protobuf3.version>
     <junit.version>4.13.1</junit.version>
     <fusionauth-jwt.version>5.2.1</fusionauth-jwt.version>
     <snakeyaml.version>2.0</snakeyaml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
     </test.additional.args>
     <!-- dependencies -->
     <jackson.version>2.15.0</jackson.version>
+    <lz4-java.version>1.10.1</lz4-java.version>
     <jackson-databind.version>2.14.2</jackson-databind.version>
     <kafka.version>3.4.1</kafka.version>
     <log4j2.version>2.24.3</log4j2.version>
@@ -82,7 +83,7 @@
     <spotbugs-maven-plugin.version>4.2.2</spotbugs-maven-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
     <maven-jacoco-plugin.version>0.8.8</maven-jacoco-plugin.version>
-    <kaml.version>0.53.0</kaml.version>
+    <kaml.version>0.104.0</kaml.version>
     <kotlinx-serialization-core.version>1.5.0</kotlinx-serialization-core.version>
     <kotlin.version>1.8.10</kotlin.version>
     <org-json.version>20231013</org-json.version>
@@ -134,6 +135,12 @@
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
         <version>${kafka.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -435,6 +442,46 @@
       <version>${pulsar.version}</version>
       <scope>provided</scope>
     </dependency>
+
+    <!-- Override the transitive netty-codec-http@4.1.119.Final to resolve vulnerability -->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http</artifactId>
+      <version>4.1.129.Final</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Override the transitive netty-codec-http2@4.1.108.Final to resolve vulnerability -->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http2</artifactId>
+      <version>4.1.125.Final</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Override the transitive jose4j@0.9.3 to resolve vulnerability -->
+    <dependency>
+      <groupId>org.bitbucket.b_c</groupId>
+      <artifactId>jose4j</artifactId>
+      <version>0.9.6</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Override the transitive vertx-web@4.5.7 to resolve vulnerability -->
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+      <version>4.5.22</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Override the transitive org.lz4:lz4-java@1.8.0 to resolve vulnerability -->
+    <dependency>
+      <groupId>at.yawk.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
+      <version>${lz4-java.version}</version>
+    </dependency>
+
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
       --add-opens java.management/sun.management=ALL-UNNAMED <!--JvmDefaultGCMetricsLogger-->
     </test.additional.args>
     <!-- dependencies -->
-    <jackson.version>2.14.2</jackson.version>
+    <jackson.version>2.15.0</jackson.version>
     <jackson-databind.version>2.14.2</jackson-databind.version>
     <kafka.version>3.4.1</kafka.version>
     <log4j2.version>2.24.3</log4j2.version>
@@ -61,8 +61,9 @@
     <awaitility.version>4.0.3</awaitility.version>
     <okhttp3.version>4.9.3</okhttp3.version>
     <gson.version>2.8.9</gson.version>
-    <commons-compress.version>1.21</commons-compress.version>
+    <commons-compress.version>1.26.0</commons-compress.version>
     <commons-configuration.version>1.10</commons-configuration.version>
+    <commons-lang3.version>3.18.0</commons-lang3.version>
     <grpc.version>1.45.1</grpc.version>
     <protobuf3.version>3.25.5</protobuf3.version>
     <junit.version>4.13.1</junit.version>
@@ -311,6 +312,11 @@
         <groupId>commons-configuration</groupId>
         <artifactId>commons-configuration</artifactId>
         <version>${commons-configuration.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${commons-lang3.version}</version>
       </dependency>
       <dependency>
         <groupId>io.fusionauth</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
     </test.additional.args>
     <!-- dependencies -->
     <jackson.version>2.15.0</jackson.version>
-    <lz4-java.version>1.10.1</lz4-java.version>
     <jackson-databind.version>2.14.2</jackson-databind.version>
     <kafka.version>3.4.1</kafka.version>
     <log4j2.version>2.24.3</log4j2.version>
@@ -135,12 +134,6 @@
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
         <version>${kafka.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.lz4</groupId>
-            <artifactId>lz4-java</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>
@@ -473,13 +466,6 @@
       <artifactId>vertx-web</artifactId>
       <version>4.5.22</version>
       <scope>provided</scope>
-    </dependency>
-
-    <!-- Override the transitive org.lz4:lz4-java@1.8.0 to resolve vulnerability -->
-    <dependency>
-      <groupId>at.yawk.lz4</groupId>
-      <artifactId>lz4-java</artifactId>
-      <version>${lz4-java.version}</version>
     </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -447,7 +447,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>4.1.129.Final</version>
+      <version>4.1.125.Final</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
Update protobuf3 version to 3.25.5 to fix cve.