### PR TITLE
Adds Netty leak detection reporting to CI and local tests

### DIFF
--- a/.github/workflows/pr-docker-tests.yml
+++ b/.github/workflows/pr-docker-tests.yml
@@ -5,12 +5,26 @@ on:
     branches:
       - 4.0_ds
   pull_request:
+  workflow_dispatch:
+    inputs:
+      netty_leak_detection:
+        description: 'Controls Netty leak detection. report: enable reporting, fail_on_leak: fail build when leaks detected, off: disable.'
+        required: true
+        type: choice
+        options:
+          - report
+          - fail_on_leak
+          - off
+        default: report
 
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      NETTY_LEAK_DETECTION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.netty_leak_detection || 'report' }}
+      NETTY_LEAK_DUMP_DIR: ${{ github.workspace }}/target/netty-leak-dumps
 
     steps:
     - uses: actions/checkout@v1
@@ -30,12 +44,26 @@ jobs:
       run: mvn test -ntp -B -DfailIfNoTests=false '-Dtest=DockerTest' -pl tests
       timeout-minutes: 120
 
+    - name: Report detected Netty leaks
+      if: ${{ always() && env.NETTY_LEAK_DETECTION != 'off' }}
+      run: bash scripts/report_netty_leaks.sh
+
+    - uses: actions/upload-artifact@master
+      name: upload netty-leak-dumps
+      if: ${{ success() && env.NETTY_LEAK_DETECTION != 'off' && hashFiles('target/netty_leaks_found') != '' }}
+      with:
+        name: netty-leak-dumps
+        path: target/netty-leak-dumps
+
     - name: package surefire artifacts
       if: failure()
       run: |
         rm -rf artifacts
         mkdir artifacts
         find . -type d -name "*surefire*" -exec cp --parents -R {} artifacts/ \;
+        if [ -d target/netty-leak-dumps ]; then
+          cp --parents -R target/netty-leak-dumps artifacts/ || true
+        fi
         zip -r artifacts.zip artifacts
 
     - uses: actions/upload-artifact@master

--- a/.github/workflows/pr-impl-test.yml
+++ b/.github/workflows/pr-impl-test.yml
@@ -5,11 +5,25 @@ on:
     branches:
       - 4.0_ds
   pull_request:
+  workflow_dispatch:
+    inputs:
+      netty_leak_detection:
+        description: 'Controls Netty leak detection. report: enable reporting, fail_on_leak: fail build when leaks detected, off: disable.'
+        required: true
+        type: choice
+        options:
+          - report
+          - fail_on_leak
+          - off
+        default: report
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      NETTY_LEAK_DETECTION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.netty_leak_detection || 'report' }}
+      NETTY_LEAK_DUMP_DIR: ${{ github.workspace }}/target/netty-leak-dumps
 
     steps:
     - uses: actions/checkout@v1
@@ -30,6 +44,17 @@ jobs:
     - name: kafka-impl test after build
       run: mvn test -ntp -B -DfailIfNoTests=false -pl kafka-impl
 
+    - name: Report detected Netty leaks
+      if: ${{ always() && env.NETTY_LEAK_DETECTION != 'off' }}
+      run: bash scripts/report_netty_leaks.sh
+
+    - uses: actions/upload-artifact@master
+      name: upload netty-leak-dumps
+      if: ${{ success() && env.NETTY_LEAK_DETECTION != 'off' && hashFiles('target/netty_leaks_found') != '' }}
+      with:
+        name: netty-leak-dumps
+        path: target/netty-leak-dumps
+
     # The DistributedClusterTest is hard to pass in CI tests environment, we disable it first
     # the track issue: https://github.com/streamnative/kop/issues/184
 #    - name: DistributedClusterTest
@@ -41,6 +66,9 @@ jobs:
         rm -rf artifacts
         mkdir artifacts
         find . -type d -name "*surefire*" -exec cp --parents -R {} artifacts/ \;
+        if [ -d target/netty-leak-dumps ]; then
+          cp --parents -R target/netty-leak-dumps artifacts/ || true
+        fi
         zip -r artifacts.zip artifacts
 
     - uses: actions/upload-artifact@master

--- a/.github/workflows/pr-proxy-tests.yml
+++ b/.github/workflows/pr-proxy-tests.yml
@@ -5,6 +5,17 @@ on:
     branches:
       - 4.0_ds
   pull_request:
+  workflow_dispatch:
+    inputs:
+      netty_leak_detection:
+        description: 'Controls Netty leak detection. report: enable reporting, fail_on_leak: fail build when leaks detected, off: disable.'
+        required: true
+        type: choice
+        options:
+          - report
+          - fail_on_leak
+          - off
+        default: report
 
 
 concurrency:
@@ -15,6 +26,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      NETTY_LEAK_DETECTION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.netty_leak_detection || 'report' }}
+      NETTY_LEAK_DUMP_DIR: ${{ github.workspace }}/target/netty-leak-dumps
 
     steps:
     - uses: actions/checkout@v1
@@ -41,6 +55,17 @@ jobs:
       run: mvn test -ntp -B -DfailIfNoTests=false '-Dtest=!Docker*Test,*Proxy*Test' -pl tests
       timeout-minutes: 120
 
+    - name: Report detected Netty leaks
+      if: ${{ always() && env.NETTY_LEAK_DETECTION != 'off' }}
+      run: bash scripts/report_netty_leaks.sh
+
+    - uses: actions/upload-artifact@master
+      name: upload netty-leak-dumps
+      if: ${{ success() && env.NETTY_LEAK_DETECTION != 'off' && hashFiles('target/netty_leaks_found') != '' }}
+      with:
+        name: netty-leak-dumps
+        path: target/netty-leak-dumps
+
     - name: Upload to Codecov
       uses: codecov/codecov-action@v3
 
@@ -50,6 +75,9 @@ jobs:
         rm -rf artifacts
         mkdir artifacts
         find . -type d -name "*surefire*" -exec cp --parents -R {} artifacts/ \;
+        if [ -d target/netty-leak-dumps ]; then
+          cp --parents -R target/netty-leak-dumps artifacts/ || true
+        fi
         zip -r artifacts.zip artifacts
 
     - uses: actions/upload-artifact@master

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -5,6 +5,17 @@ on:
     branches:
       - 4.0_ds
   pull_request:
+  workflow_dispatch:
+    inputs:
+      netty_leak_detection:
+        description: 'Controls Netty leak detection. report: enable reporting, fail_on_leak: fail build when leaks detected, off: disable.'
+        required: true
+        type: choice
+        options:
+          - report
+          - fail_on_leak
+          - off
+        default: report
 
 
 concurrency:
@@ -15,6 +26,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      NETTY_LEAK_DETECTION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.netty_leak_detection || 'report' }}
+      NETTY_LEAK_DUMP_DIR: ${{ github.workspace }}/target/netty-leak-dumps
 
     steps:
     - uses: actions/checkout@v1
@@ -44,6 +58,17 @@ jobs:
       run: mvn test -ntp -B -DfailIfNoTests=false '-Dtest=!Docker*Test,!*Proxy*Test' -pl tests
       timeout-minutes: 120
 
+    - name: Report detected Netty leaks
+      if: ${{ always() && env.NETTY_LEAK_DETECTION != 'off' }}
+      run: bash scripts/report_netty_leaks.sh
+
+    - uses: actions/upload-artifact@master
+      name: upload netty-leak-dumps
+      if: ${{ success() && env.NETTY_LEAK_DETECTION != 'off' && hashFiles('target/netty_leaks_found') != '' }}
+      with:
+        name: netty-leak-dumps
+        path: target/netty-leak-dumps
+
     - name: Upload to Codecov
       uses: codecov/codecov-action@v3
 
@@ -53,6 +78,9 @@ jobs:
         rm -rf artifacts
         mkdir artifacts
         find . -type d -name "*surefire*" -exec cp --parents -R {} artifacts/ \;
+        if [ -d target/netty-leak-dumps ]; then
+          cp --parents -R target/netty-leak-dumps artifacts/ || true
+        fi
         zip -r artifacts.zip artifacts
 
     - uses: actions/upload-artifact@master

--- a/README.md
+++ b/README.md
@@ -27,5 +27,72 @@ Starlight for Kafka adds additional features to make native Kafka protocol suppo
 
 For documentation, see the [Starlight for Kafka documentation](https://docs.datastax.com/en/starlight-kafka/docs/1.0/index.html).
 
+## CI: Netty leak detection reporting
 
+This repo's CI is able to report Netty `ByteBuf` leak detection messages (and optionally fail the workflow when leaks
+are found).
 
+### GitHub Actions (manual run)
+
+The following workflows support `workflow_dispatch` with an input called `netty_leak_detection`:
+
+- `kop tests` (`.github/workflows/pr-tests.yml`)
+- `kop mvn build check and kafka-impl test` (`.github/workflows/pr-impl-test.yml`)
+- `kop proxy tests` (`.github/workflows/pr-proxy-tests.yml`)
+- `docker tests` (`.github/workflows/pr-docker-tests.yml`)
+
+Modes:
+
+- `report` (default): report leaks as warnings in the job logs
+- `fail_on_leak`: report leaks and fail the job when leaks are detected
+- `off`: disable leak reporting
+
+### Local runs
+
+This project uses a custom Netty leak detector (`ExtendedNettyLeakDetector`) that dumps detected leaks to files named
+`netty_leak_*.txt` under `NETTY_LEAK_DUMP_DIR`. The CI step `scripts/report_netty_leaks.sh` reports leaks based on
+those dump files.
+
+By default, unit tests run with Netty leak detection level `paranoid` (configurable via `-DtestLeakDetectionLevel`).
+
+To get consistent results locally, set `NETTY_LEAK_DUMP_DIR` before running tests so the detector and the report script
+look at the same directory:
+
+```bash
+export NETTY_LEAK_DETECTION=report
+export NETTY_LEAK_DUMP_DIR=$PWD/target/netty-leak-dumps
+
+mvn test -pl kafka-impl
+bash scripts/report_netty_leaks.sh
+```
+
+To disable Netty leak detection in the test JVMs, set `NETTY_LEAK_DETECTION=off` before running Maven (this activates a
+Maven profile that removes the leak detection JVM args):
+
+```bash
+export NETTY_LEAK_DETECTION=off
+mvn test -pl kafka-impl
+```
+
+For Testcontainers-based tests (module `tests`), setting `NETTY_LEAK_DETECTION` also enables leak detection-related JVM
+flags inside the Pulsar/Proxy containers. The leak dumps are written under `NETTY_LEAK_DUMP_DIR/containers/<name>/`.
+
+```bash
+export NETTY_LEAK_DETECTION=report
+export NETTY_LEAK_DUMP_DIR=$PWD/target/netty-leak-dumps
+
+mvn test -pl tests -DfailIfNoTests=false -Dtest=DockerTest
+bash scripts/report_netty_leaks.sh
+```
+
+To make Netty leaks fail the check locally, use `fail_on_leak`:
+
+```bash
+NETTY_LEAK_DETECTION=fail_on_leak bash scripts/report_netty_leaks.sh
+```
+
+For debugging, you can also make the test JVM exit immediately on the first detected leak:
+
+```bash
+mvn test -pl kafka-impl -DtestExitJvmOnLeak=true
+```

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,28 @@
       --add-opens java.base/sun.net=ALL-UNNAMED <!--netty.DnsResolverUtil-->
       --add-opens java.management/sun.management=ALL-UNNAMED <!--JvmDefaultGCMetricsLogger-->
     </test.additional.args>
+    <!-- Netty leak detection defaults in tests (aligned with Apache Pulsar CI conventions). -->
+    <testExitJvmOnLeak>false</testExitJvmOnLeak>
+    <testExitJvmOnLeakDelayMillis>1000</testExitJvmOnLeakDelayMillis>
+    <testLeakDetectionLevel>paranoid</testLeakDetectionLevel>
+    <test.netty.args>
+      <!-- required for triggering GC to trigger leak detection synchronously in tests -->
+      -XX:+UnlockExperimentalVMOptions -XX:ReferencesPerThread=0 -XX:+ParallelRefProcEnabled
+      -Dio.netty.tryReflectionSetAccessible=true
+      -Dorg.apache.pulsar.shade.io.netty.tryReflectionSetAccessible=true
+    </test.netty.args>
+    <test.netty.leakdetection.args>
+      -Dpulsar.allocator.pooled=false
+      -Dpulsar.allocator.leak_detection=Advanced
+      -Dio.netty.customResourceLeakDetector=io.streamnative.pulsar.handlers.kop.common.test.ExtendedNettyLeakDetector
+      -Dio.streamnative.pulsar.handlers.kop.common.test.ExtendedNettyLeakDetector.exitJvmOnLeak=${testExitJvmOnLeak}
+      -Dio.streamnative.pulsar.handlers.kop.common.test.ExtendedNettyLeakDetector.exitJvmDelayMillis=${testExitJvmOnLeakDelayMillis}
+      -Dio.netty.leakDetection.level=${testLeakDetectionLevel}
+      <!-- allows using paranoid leak detection with relatively low overhead -->
+      -Dio.netty.leakDetection.targetRecords=16
+      -Dio.netty.leakDetection.acquireAndReleaseOnly=true
+      -Dio.netty.leakDetection.samplingInterval=32
+    </test.netty.leakdetection.args>
     <!-- dependencies -->
     <jackson.version>2.14.2</jackson.version>
     <jackson-databind.version>2.14.2</jackson-databind.version>
@@ -618,8 +640,8 @@
         <version>${maven-surefire-plugin.version}</version>
         <configuration>
           <argLine>@{argLine} -Xmx2G
-            -Dpulsar.allocator.pooled=false
-            -Dpulsar.allocator.leak_detection=Advanced
+            ${test.netty.args}
+            ${test.netty.leakdetection.args}
             -Dlog4j.configurationFile="log4j2.xml"
             ${test.additional.args}
           </argLine>
@@ -793,6 +815,21 @@
   </distributionManagement>
 
   <profiles>
+    <!-- This profile is used to disable Netty leak detection in tests. It is activated by setting the
+         environment variable NETTY_LEAK_DETECTION to off. -->
+    <profile>
+      <id>disableNettyLeakDetection</id>
+      <activation>
+        <property>
+          <name>env.NETTY_LEAK_DETECTION</name>
+          <value>off</value>
+        </property>
+      </activation>
+      <properties>
+        <test.netty.leakdetection.args></test.netty.leakdetection.args>
+      </properties>
+    </profile>
+
     <profile>
       <id>release</id>
       <build>

--- a/scripts/report_netty_leaks.sh
+++ b/scripts/report_netty_leaks.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -euo pipefail
+
+NETTY_LEAK_DETECTION="${NETTY_LEAK_DETECTION:-report}"
+NETTY_LEAK_DUMP_DIR="${NETTY_LEAK_DUMP_DIR:-${GITHUB_WORKSPACE:-$(pwd)}/target/netty-leak-dumps}"
+
+case "${NETTY_LEAK_DETECTION}" in
+  report|fail_on_leak|off)
+    ;;
+  *)
+    echo "::warning::Unknown NETTY_LEAK_DETECTION='${NETTY_LEAK_DETECTION}', falling back to 'report'."
+    NETTY_LEAK_DETECTION="report"
+    ;;
+esac
+
+if [[ "${NETTY_LEAK_DETECTION}" == "off" ]]; then
+  echo "Netty leak detection reporting is disabled (NETTY_LEAK_DETECTION=off)."
+  exit 0
+fi
+
+mkdir -p "${NETTY_LEAK_DUMP_DIR}"
+mkdir -p target
+
+tmp_leak_details="$(mktemp -t netty-leak-details.XXXXXX)"
+tmp_dump_files_list="$(mktemp -t netty-leak-dumps.XXXXXX)"
+trap 'rm -f "${tmp_leak_details}" "${tmp_dump_files_list}"' EXIT
+
+if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+  echo "::group::Netty leak detection report"
+fi
+
+echo "NETTY_LEAK_DETECTION=${NETTY_LEAK_DETECTION}"
+echo "NETTY_LEAK_DUMP_DIR=${NETTY_LEAK_DUMP_DIR}"
+
+annotation_prefix="::warning::"
+if [[ "${NETTY_LEAK_DETECTION}" == "fail_on_leak" ]]; then
+  annotation_prefix="::error::"
+fi
+
+find "${NETTY_LEAK_DUMP_DIR}" -type f -name "netty_leak_*.txt" -print 2>/dev/null \
+  | sort -u > "${tmp_dump_files_list}" || true
+
+if [[ ! -s "${tmp_dump_files_list}" ]]; then
+  echo "No Netty leak markers found."
+  touch target/netty_leaks_not_found
+  if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    echo "::endgroup::"
+  fi
+  exit 0
+fi
+
+touch target/netty_leaks_found
+
+report_file="${NETTY_LEAK_DUMP_DIR}/leak_report.txt"
+{
+  echo "${annotation_prefix}Netty leaks found (mode=${NETTY_LEAK_DETECTION})."
+  echo
+  echo "Detected Netty leak dump files:"
+  cat "${tmp_dump_files_list}"
+  echo
+
+  echo "Details:"
+  while IFS= read -r file; do
+    if [[ -f "${file}" ]]; then
+      cat "${file}" >> "${tmp_leak_details}"
+    fi
+  done < "${tmp_dump_files_list}"
+  cat "${tmp_leak_details}"
+} | tee "${report_file}"
+
+if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+  echo "::endgroup::"
+fi
+
+if [[ "${NETTY_LEAK_DETECTION}" == "fail_on_leak" ]]; then
+  exit 1
+fi

--- a/test-listener/src/main/java/io/streamnative/pulsar/handlers/kop/common/test/ExtendedNettyLeakDetector.java
+++ b/test-listener/src/main/java/io/streamnative/pulsar/handlers/kop/common/test/ExtendedNettyLeakDetector.java
@@ -1,0 +1,265 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.common.test;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.ResourceLeakDetector;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Custom Netty {@link ResourceLeakDetector} that dumps detected leaks to files in a directory configured with
+ * {@code NETTY_LEAK_DUMP_DIR}.
+ *
+ * <p>This is intended for CI usage to make leak reporting reliable even when test output is redirected to files.
+ */
+public class ExtendedNettyLeakDetector<T> extends ResourceLeakDetector<T> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExtendedNettyLeakDetector.class);
+
+    public static final String NETTY_CUSTOM_LEAK_DETECTOR_SYSTEM_PROPERTY_NAME =
+            "io.netty.customResourceLeakDetector";
+    public static final String USE_SHUTDOWN_HOOK_SYSTEM_PROPERTY_NAME =
+            ExtendedNettyLeakDetector.class.getName() + ".useShutdownHook";
+    public static final String EXIT_JVM_ON_LEAK_SYSTEM_PROPERTY_NAME =
+            ExtendedNettyLeakDetector.class.getName() + ".exitJvmOnLeak";
+    public static final String EXIT_JVM_DELAY_MILLIS_SYSTEM_PROPERTY_NAME =
+            ExtendedNettyLeakDetector.class.getName() + ".exitJvmDelayMillis";
+    public static final String SLEEP_AFTER_GC_AND_FINALIZATION_MILLIS_SYSTEM_PROPERTY_NAME =
+            ExtendedNettyLeakDetector.class.getName() + ".sleepAfterGCAndFinalizationMillis";
+    public static final String NETTY_LEAK_DETECTION_ENV = "NETTY_LEAK_DETECTION";
+    public static final String NETTY_LEAK_DUMP_DIR_ENV = "NETTY_LEAK_DUMP_DIR";
+
+    private static final String MODE_REPORT = "report";
+    private static final String MODE_FAIL_ON_LEAK = "fail_on_leak";
+    private static final String MODE_OFF = "off";
+    private static final long DEFAULT_EXIT_JVM_DELAY_MILLIS = 1000L;
+    private static final long DEFAULT_SLEEP_AFTER_GC_AND_FINALIZATION_MILLIS = 10L;
+
+    private static final AtomicLong DUMP_COUNTER = new AtomicLong();
+    private static final DateTimeFormatter DUMP_TIMESTAMP_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss.SSS", Locale.ROOT);
+
+    private static final String MODE = normalizeMode(System.getenv(NETTY_LEAK_DETECTION_ENV));
+    private static final File DUMP_DIR = new File(System.getenv().getOrDefault(NETTY_LEAK_DUMP_DIR_ENV,
+            System.getProperty("java.io.tmpdir")));
+    private static final boolean USE_SHUTDOWN_HOOK = Boolean.parseBoolean(
+            System.getProperty(USE_SHUTDOWN_HOOK_SYSTEM_PROPERTY_NAME, "false"));
+    private static boolean exitJvmOnLeak = Boolean.parseBoolean(
+            System.getProperty(EXIT_JVM_ON_LEAK_SYSTEM_PROPERTY_NAME, "false"));
+    private static final boolean DEFAULT_EXIT_JVM_ON_LEAK = exitJvmOnLeak;
+    private static final long EXIT_JVM_DELAY_MILLIS = Long.parseLong(System.getProperty(
+            EXIT_JVM_DELAY_MILLIS_SYSTEM_PROPERTY_NAME, String.valueOf(DEFAULT_EXIT_JVM_DELAY_MILLIS)));
+    private static final long SLEEP_AFTER_GC_AND_FINALIZATION_MILLIS = Long.parseLong(System.getProperty(
+            SLEEP_AFTER_GC_AND_FINALIZATION_MILLIS_SYSTEM_PROPERTY_NAME,
+            String.valueOf(DEFAULT_SLEEP_AFTER_GC_AND_FINALIZATION_MILLIS)));
+
+    private static volatile String initialHint;
+
+    static {
+        if (MODE_OFF.equals(MODE)) {
+            ResourceLeakDetector.setEnabled(false);
+            ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.DISABLED);
+        } else {
+            maybeRegisterShutdownHook();
+        }
+    }
+
+    public static void setInitialHint(String initialHint) {
+        ExtendedNettyLeakDetector.initialHint = initialHint;
+    }
+
+    public static boolean isExtendedNettyLeakDetectorEnabled() {
+        return ExtendedNettyLeakDetector.class.getName()
+                .equals(System.getProperty(NETTY_CUSTOM_LEAK_DETECTOR_SYSTEM_PROPERTY_NAME));
+    }
+
+    @SuppressFBWarnings(value = "DM_GC",
+            justification = "Used to increase reliability of Netty leak detection flushing in CI/test runs.")
+    public static void triggerLeakDetection() {
+        if (MODE_OFF.equals(MODE) || !isExtendedNettyLeakDetectorEnabled() || !isEnabled()) {
+            return;
+        }
+        try {
+            System.gc();
+            System.runFinalization();
+            Thread.sleep(SLEEP_AFTER_GC_AND_FINALIZATION_MILLIS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        triggerLeakReporting();
+    }
+
+    private static void triggerLeakReporting() {
+        ByteBuf buffer = ByteBufAllocator.DEFAULT.directBuffer();
+        ByteBuf retainedSlice = buffer.retainedSlice();
+        retainedSlice.release();
+        buffer.release();
+    }
+
+    public static void disableExitJVMOnLeak() {
+        exitJvmOnLeak = false;
+    }
+
+    public static void restoreExitJVMOnLeak() {
+        triggerLeakDetection();
+        exitJvmOnLeak = DEFAULT_EXIT_JVM_ON_LEAK;
+    }
+
+    public ExtendedNettyLeakDetector(Class<?> resourceType) {
+        super(resourceType);
+    }
+
+    public ExtendedNettyLeakDetector(String resourceType) {
+        super(resourceType);
+    }
+
+    public ExtendedNettyLeakDetector(Class<?> resourceType, int samplingInterval, long maxActive) {
+        super(resourceType, samplingInterval, maxActive);
+    }
+
+    public ExtendedNettyLeakDetector(Class<?> resourceType, int samplingInterval) {
+        super(resourceType, samplingInterval);
+    }
+
+    public ExtendedNettyLeakDetector(String resourceType, int samplingInterval, long maxActive) {
+        super(resourceType, samplingInterval, maxActive);
+    }
+
+    private boolean exitThreadStarted;
+
+    @Override
+    protected boolean needReport() {
+        return true;
+    }
+
+    @Override
+    protected void reportTracedLeak(String resourceType, String records) {
+        super.reportTracedLeak(resourceType, records);
+        dumpToFile(resourceType, records);
+        maybeExitJVM();
+    }
+
+    @Override
+    protected void reportUntracedLeak(String resourceType) {
+        super.reportUntracedLeak(resourceType);
+        dumpToFile(resourceType, null);
+        maybeExitJVM();
+    }
+
+    @Override
+    protected void reportInstancesLeak(String resourceType) {
+        super.reportInstancesLeak(resourceType);
+        dumpToFile(resourceType, null);
+        maybeExitJVM();
+    }
+
+    @Override
+    protected Object getInitialHint(String resourceType) {
+        String hint = initialHint;
+        if (hint != null) {
+            return hint;
+        }
+        return super.getInitialHint(resourceType);
+    }
+
+    private synchronized void maybeExitJVM() {
+        if (exitThreadStarted || !exitJvmOnLeak) {
+            return;
+        }
+        new Thread(() -> {
+            LOG.error("Exiting JVM due to Netty resource leak. Dumped to {}", DUMP_DIR.getAbsolutePath());
+            System.err.println("Exiting JVM due to Netty resource leak. Dumped to " + DUMP_DIR.getAbsolutePath());
+            triggerLeakDetectionBeforeJVMExit();
+            System.err.flush();
+            System.out.flush();
+            Runtime.getRuntime().halt(1);
+        }, ExtendedNettyLeakDetector.class.getSimpleName() + "ExitThread").start();
+        exitThreadStarted = true;
+    }
+
+    private static void maybeRegisterShutdownHook() {
+        if (!exitJvmOnLeak && USE_SHUTDOWN_HOOK && isExtendedNettyLeakDetectorEnabled()) {
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                if (!isEnabled()) {
+                    return;
+                }
+                triggerLeakDetectionBeforeJVMExit();
+            }, ExtendedNettyLeakDetector.class.getSimpleName() + "ShutdownHook"));
+        }
+    }
+
+    private static void triggerLeakDetectionBeforeJVMExit() {
+        triggerLeakDetection();
+        try {
+            Thread.sleep(EXIT_JVM_DELAY_MILLIS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        triggerLeakDetection();
+    }
+
+    private void dumpToFile(String resourceType, String records) {
+        if (MODE_OFF.equals(MODE)) {
+            return;
+        }
+        try {
+            if (!DUMP_DIR.exists() && !DUMP_DIR.mkdirs()) {
+                LOG.warn("Cannot create NETTY_LEAK_DUMP_DIR={}", DUMP_DIR.getAbsolutePath());
+                return;
+            }
+            String timestampPart = DUMP_TIMESTAMP_FORMATTER.format(ZonedDateTime.now());
+            long counter = DUMP_COUNTER.incrementAndGet();
+            File dumpFile = new File(DUMP_DIR, "netty_leak_" + timestampPart + "_" + counter + ".txt");
+            String prefix = exitJvmOnLeak ? "::error::" : "::warning::";
+
+            StringBuilder report = new StringBuilder();
+            if (records != null) {
+                report.append(prefix).append("Traced leak detected ").append(resourceType).append('\n');
+                report.append(records).append('\n');
+            } else {
+                report.append(prefix).append("Untraced leak detected ").append(resourceType).append('\n');
+            }
+            report.append('\n');
+
+            Files.writeString(dumpFile.toPath(), report.toString(), StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            LOG.warn("Failed to write Netty leak report to NETTY_LEAK_DUMP_DIR={}",
+                    DUMP_DIR.getAbsolutePath(), e);
+        }
+    }
+
+    private static String normalizeMode(String mode) {
+        if (mode == null) {
+            return MODE_REPORT;
+        }
+        String normalized = mode.trim().toLowerCase(Locale.ROOT);
+        if (MODE_REPORT.equals(normalized) || MODE_FAIL_ON_LEAK.equals(normalized) || MODE_OFF.equals(normalized)) {
+            return normalized;
+        }
+        return MODE_REPORT;
+    }
+}

--- a/test-listener/src/main/java/io/streamnative/pulsar/handlers/kop/common/test/TimeOutTestListener.java
+++ b/test-listener/src/main/java/io/streamnative/pulsar/handlers/kop/common/test/TimeOutTestListener.java
@@ -27,6 +27,10 @@ import java.util.Map;
 import javax.management.JMException;
 import javax.management.ObjectName;
 import lombok.extern.slf4j.Slf4j;
+import org.testng.IExecutionListener;
+import org.testng.ISuite;
+import org.testng.ISuiteListener;
+import org.testng.ITestContext;
 import org.testng.ITestResult;
 import org.testng.TestListenerAdapter;
 import org.testng.internal.thread.ThreadTimeoutException;
@@ -36,7 +40,9 @@ import org.testng.internal.thread.ThreadTimeoutException;
  * in case a test is failed due to timeout.
  */
 @Slf4j
-public class TimeOutTestListener extends TestListenerAdapter {
+public class TimeOutTestListener extends TestListenerAdapter implements IExecutionListener, ISuiteListener {
+
+    private static final String NETTY_LEAK_DETECTION_ENV = "NETTY_LEAK_DETECTION";
 
     private static void print(String prefix, ITestResult tr) {
         if (tr.getParameters() != null && tr.getParameters().length > 0) {
@@ -51,6 +57,8 @@ public class TimeOutTestListener extends TestListenerAdapter {
 
     @Override
     public void onTestStart(ITestResult tr) {
+        ExtendedNettyLeakDetector.setInitialHint(String.format("Test: %s.%s",
+                tr.getTestClass().getName(), tr.getMethod().getMethodName()));
         print("onTestStart", tr);
         super.onTestStart(tr);
     }
@@ -59,6 +67,7 @@ public class TimeOutTestListener extends TestListenerAdapter {
     public void onTestSuccess(ITestResult tr) {
         print("onTestSuccess", tr);
         super.onTestSuccess(tr);
+        maybeTriggerNettyLeakDetection();
     }
 
     @Override
@@ -71,6 +80,7 @@ public class TimeOutTestListener extends TestListenerAdapter {
     public void onTestFailedButWithinSuccessPercentage(ITestResult tr) {
         print("onTestFailedButWithinSuccessPercentage", tr);
         super.onTestFailedButWithinSuccessPercentage(tr);
+        maybeTriggerNettyLeakDetection();
     }
 
     @Override
@@ -84,6 +94,54 @@ public class TimeOutTestListener extends TestListenerAdapter {
             System.err.println();
             System.err.print(ThreadDumpUtil.buildThreadDiagnosticString());
         }
+        maybeTriggerNettyLeakDetection();
+    }
+
+    @Override
+    public void onFinish(ITestContext testContext) {
+        maybeTriggerNettyLeakDetection();
+        ExtendedNettyLeakDetector.setInitialHint("Finished test: " + testContext.getName());
+        super.onFinish(testContext);
+    }
+
+    private static void maybeTriggerNettyLeakDetection() {
+        String mode = System.getenv(NETTY_LEAK_DETECTION_ENV);
+        if (mode != null && "off".equalsIgnoreCase(mode.trim())) {
+            return;
+        }
+        ExtendedNettyLeakDetector.triggerLeakDetection();
+    }
+
+    @Override
+    public void onExecutionStart() {
+        ExtendedNettyLeakDetector.setInitialHint("Starting test execution");
+    }
+
+    @Override
+    public void onExecutionFinish() {
+        if (!ExtendedNettyLeakDetector.isExtendedNettyLeakDetectorEnabled()) {
+            return;
+        }
+        if (!ExtendedNettyLeakDetector.isEnabled()) {
+            return;
+        }
+        ExtendedNettyLeakDetector.triggerLeakDetection();
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        ExtendedNettyLeakDetector.triggerLeakDetection();
+    }
+
+    @Override
+    public void onFinish(ISuite suite) {
+        ExtendedNettyLeakDetector.setInitialHint("Finished suite: " + suite.getName());
+    }
+
+    @Override
+    public void onStart(ISuite suite) {
+        ExtendedNettyLeakDetector.setInitialHint("Starting suite: " + suite.getName());
     }
 
     /**

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/docker/PulsarContainer.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/docker/PulsarContainer.java
@@ -15,16 +15,26 @@ package io.streamnative.pulsar.handlers.kop.docker;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.streamnative.pulsar.handlers.kop.common.test.ExtendedNettyLeakDetector;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.MountableFile;
@@ -35,6 +45,13 @@ public class PulsarContainer implements AutoCloseable {
     protected static final String PROTOCOLS_TEST_PROTOCOL_HANDLER_NAR = "/protocols/test-protocol-handler.nar";
     protected static final String PROXY_EXTENSION_TEST_NAR = "/proxyextensions/test-proxy-extension.nar";
     public static final String ZOOKEEPER_3_7_2 = "zookeeper:3.7.2";
+    private static final String NETTY_LEAK_DETECTION_ENV = "NETTY_LEAK_DETECTION";
+    private static final String NETTY_LEAK_DUMP_DIR_ENV = "NETTY_LEAK_DUMP_DIR";
+    private static final String PULSAR_EXTRA_OPTS_ENV = "PULSAR_EXTRA_OPTS";
+    private static final String PULSAR_EXTRA_CLASSPATH_ENV = "PULSAR_EXTRA_CLASSPATH";
+    private static final String CONTAINER_NETTY_LEAK_DUMP_DIR = "/pulsar/netty-leak-dumps";
+    private static final String CONTAINER_NETTY_LEAK_DETECTOR_JAR =
+            "/pulsar/lib/kop-netty-leak-detector.jar";
 
     @Getter
     private GenericContainer<?> pulsarContainer;
@@ -116,6 +133,7 @@ public class PulsarContainer implements AutoCloseable {
                                     log.info(text);
                                 });
         pulsarContainer.withEnv("PULSAR_LOG_LEVEL", "info");
+        maybeEnableNettyLeakDetection(pulsarContainer, "pulsar");
         pulsarContainer.withEnv("PULSAR_PREFIX_brokerClientAuthenticationPlugin",
                 "org.apache.pulsar.client.impl.auth.AuthenticationToken");
         pulsarContainer.withEnv("PULSAR_PREFIX_brokerClientAuthenticationParameters",
@@ -224,6 +242,7 @@ public class PulsarContainer implements AutoCloseable {
                                     });
             proxyContainer.withEnv("JAVA_JDK_OPTIONS", "-Djdk.tls.disabledAlgorithms=");
             proxyContainer.withEnv("PULSAR_LOG_LEVEL", "info");
+            maybeEnableNettyLeakDetection(proxyContainer, "pulsarproxy");
             proxyContainer.withEnv("PULSAR_PREFIX_brokerServiceURL", "pulsar://pulsar:6650");
             proxyContainer.withEnv("PULSAR_PREFIX_brokerWebServiceURL", "http://pulsar:8080");
             proxyContainer.withEnv("PULSAR_PREFIX_brokerClientAuthenticationPlugin",
@@ -295,6 +314,117 @@ public class PulsarContainer implements AutoCloseable {
         if (zookeeperContainer != null) {
             zookeeperContainer.stop();
         }
+    }
+
+    private static void maybeEnableNettyLeakDetection(GenericContainer<?> container, String name) {
+        String mode = System.getenv(NETTY_LEAK_DETECTION_ENV);
+        if (mode == null || mode.isBlank() || "off".equalsIgnoreCase(mode)) {
+            return;
+        }
+        String hostDumpDir = System.getenv(NETTY_LEAK_DUMP_DIR_ENV);
+        if (hostDumpDir != null && !hostDumpDir.isBlank()) {
+            try {
+                Path containerDumpDir = Paths.get(hostDumpDir, "containers", name);
+                Files.createDirectories(containerDumpDir);
+                makeWorldWritable(containerDumpDir);
+                container.withFileSystemBind(containerDumpDir.toString(), CONTAINER_NETTY_LEAK_DUMP_DIR,
+                        BindMode.READ_WRITE);
+                container.withEnv(NETTY_LEAK_DUMP_DIR_ENV, CONTAINER_NETTY_LEAK_DUMP_DIR);
+            } catch (IOException e) {
+                log.warn("Failed to setup Netty leak dump directory bind mount for container {}", name, e);
+            }
+        }
+        container.withEnv(NETTY_LEAK_DETECTION_ENV, mode);
+
+        boolean customLeakDetectorAvailable = false;
+        try {
+            Path leakDetectorJar = createLeakDetectorJar();
+            MountableFile leakDetectorJarFile = MountableFile.forHostPath(leakDetectorJar, 0644);
+            container.withCopyFileToContainer(leakDetectorJarFile, CONTAINER_NETTY_LEAK_DETECTOR_JAR);
+            customLeakDetectorAvailable = true;
+        } catch (IOException e) {
+            log.warn("Failed to create/copy Netty leak detector jar to container {}", name, e);
+        }
+
+        // Mirror defaults used by unit tests (see root pom.xml surefire argLine).
+        String leakDetectionLevel = System.getProperty("io.netty.leakDetection.level", "paranoid");
+        String leakDetectionTargetRecords = System.getProperty("io.netty.leakDetection.targetRecords", "16");
+        String leakDetectionAcquireAndReleaseOnly =
+                System.getProperty("io.netty.leakDetection.acquireAndReleaseOnly", "true");
+        String leakDetectionSamplingInterval = System.getProperty("io.netty.leakDetection.samplingInterval", "32");
+        String tryReflectionSetAccessible = System.getProperty("io.netty.tryReflectionSetAccessible", "true");
+        String tryReflectionSetAccessibleShaded =
+                System.getProperty("org.apache.pulsar.shade.io.netty.tryReflectionSetAccessible", "true");
+        String exitJvmOnLeak = System.getProperty(ExtendedNettyLeakDetector.EXIT_JVM_ON_LEAK_SYSTEM_PROPERTY_NAME,
+                "false");
+        String exitJvmDelayMillis = System.getProperty(
+                ExtendedNettyLeakDetector.EXIT_JVM_DELAY_MILLIS_SYSTEM_PROPERTY_NAME, "1000");
+
+        String leakDetectionOpts = "-XX:+UnlockExperimentalVMOptions -XX:ReferencesPerThread=0 "
+                + "-XX:+ParallelRefProcEnabled "
+                + "-Dpulsar.allocator.pooled=false "
+                + "-Dpulsar.allocator.leak_detection=Advanced "
+                + "-Dio.netty.tryReflectionSetAccessible=" + tryReflectionSetAccessible + " "
+                + "-Dorg.apache.pulsar.shade.io.netty.tryReflectionSetAccessible=" + tryReflectionSetAccessibleShaded
+                + " "
+                + "-Dio.netty.leakDetection.level=" + leakDetectionLevel + " "
+                + "-Dio.netty.leakDetection.targetRecords=" + leakDetectionTargetRecords + " "
+                + "-Dio.netty.leakDetection.acquireAndReleaseOnly=" + leakDetectionAcquireAndReleaseOnly + " "
+                + "-Dio.netty.leakDetection.samplingInterval=" + leakDetectionSamplingInterval + " "
+                + "-D" + ExtendedNettyLeakDetector.EXIT_JVM_ON_LEAK_SYSTEM_PROPERTY_NAME + "=" + exitJvmOnLeak + " "
+                + "-D" + ExtendedNettyLeakDetector.EXIT_JVM_DELAY_MILLIS_SYSTEM_PROPERTY_NAME + "="
+                + exitJvmDelayMillis;
+        if (customLeakDetectorAvailable) {
+            leakDetectionOpts = leakDetectionOpts
+                    + " -Dio.netty.customResourceLeakDetector=" + ExtendedNettyLeakDetector.class.getName()
+                    + " -D" + ExtendedNettyLeakDetector.USE_SHUTDOWN_HOOK_SYSTEM_PROPERTY_NAME + "=true";
+            container.withEnv(PULSAR_EXTRA_CLASSPATH_ENV, CONTAINER_NETTY_LEAK_DETECTOR_JAR);
+        }
+        container.withEnv(PULSAR_EXTRA_OPTS_ENV, leakDetectionOpts);
+    }
+
+    private static void makeWorldWritable(Path path) {
+        try {
+            Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("rwxrwxrwx");
+            Files.setPosixFilePermissions(path, permissions);
+        } catch (UnsupportedOperationException e) {
+            log.debug("Posix permissions not supported for {}, skipping chmod", path);
+        } catch (IOException e) {
+            log.debug("Failed to set chmod 777 on {}, skipping", path, e);
+        }
+    }
+
+    private static void makeWorldReadable(Path path) {
+        try {
+            Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("rw-r--r--");
+            Files.setPosixFilePermissions(path, permissions);
+        } catch (UnsupportedOperationException e) {
+            log.debug("Posix permissions not supported for {}, skipping chmod", path);
+        } catch (IOException e) {
+            log.debug("Failed to set chmod 644 on {}, skipping", path, e);
+        }
+    }
+
+    private static Path createLeakDetectorJar() throws IOException {
+        Path jarPath = Files.createTempFile("kop-netty-leak-detector-", ".jar");
+        jarPath.toFile().deleteOnExit();
+
+        String classEntryName = ExtendedNettyLeakDetector.class.getName().replace('.', '/') + ".class";
+        String classResourcePath = "/" + classEntryName;
+
+        try (JarOutputStream jarOut = new JarOutputStream(Files.newOutputStream(jarPath))) {
+            jarOut.putNextEntry(new JarEntry(classEntryName));
+            try (InputStream in = ExtendedNettyLeakDetector.class.getResourceAsStream(classResourcePath)) {
+                if (in == null) {
+                    throw new IOException("Cannot load class bytes for " + classResourcePath);
+                }
+                in.transferTo(jarOut);
+            }
+            jarOut.closeEntry();
+            jarOut.flush();
+        }
+        makeWorldReadable(jarPath);
+        return jarPath;
     }
 
     protected Path getProtocolHandlerPath() {


### PR DESCRIPTION
### Motivation

Netty `ByteBuf` leak signals were difficult to reliably capture and triage in CI (especially when logs are redirected or when tests run inside containers). This PR makes leak reporting deterministic by dumping detected leaks to files and adds a simple CI-friendly reporting step, with an option to fail builds when leaks are found.

### Modifications

* Added a custom `ResourceLeakDetector` (`ExtendedNettyLeakDetector`) that:

  * dumps traced/untraced leak reports into `NETTY_LEAK_DUMP_DIR`,
  * supports modes via `NETTY_LEAK_DETECTION` (`report`, `fail_on_leak`, `off`),
  * provides “initial hint” context and optional JVM-exit behavior for debugging.
* Enhanced the TestNG listener (`TimeOutTestListener`) to:

  * set contextual hints at suite/test boundaries,
  * proactively trigger leak detection on test completion and at execution finish.
* Updated Maven Surefire defaults to enable Netty leak detection consistently in tests, with a profile to disable it when `NETTY_LEAK_DETECTION=off`.
* Improved Docker-based integration tests to enable leak detection inside the Pulsar container:

  * bind-mount leak dump directory back to the host,
  * inject the leak-detector class via a small jar and set `PULSAR_EXTRA_OPTS` / `PULSAR_EXTRA_CLASSPATH`.
* Added `scripts/report_netty_leaks.sh` and wired GitHub Actions workflows to:

  * run leak reporting unconditionally (unless disabled),
  * optionally fail on leaks,
  * upload leak dump artifacts when leaks are present.
* Documented local/CI usage in `README.md`.
