### PR TITLE
Complete ResponseCallbackWrapper on encoding failure

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -467,6 +467,9 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
                         result = responseToByteBuf(response, request, true);
                     } catch (Throwable error) {
                         log.error("[{}] Failed to convert response {} to ByteBuf", channel, response, error);
+                        if (response instanceof ResponseCallbackWrapper) {
+                            ((ResponseCallbackWrapper) response).responseComplete();
+                        }
                         sendErrorResponse(request, channel, error, true);
                         return;
                     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -1211,14 +1211,19 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
         final int numMessages = 10;
         final KafkaProducer<String, String> producer = createKafkaProducer();
         produceData(producer, Collections.singletonList(new TopicPartition(topic, 0)), numMessages);
-        AbstractResponse abstractResponse = ((ResponseCallbackWrapper)
-                future.get(maxWaitMs + 1000, TimeUnit.MILLISECONDS)).getResponse();
-        assertTrue(abstractResponse instanceof FetchResponse);
-        final FetchResponse response = (FetchResponse) abstractResponse;
-        assertEquals(response.error(), Errors.NONE);
-        final long endTime = System.currentTimeMillis();
-        log.info("Take {} ms to process FETCH request", endTime - startTime);
-        assertTrue(endTime - startTime <= maxWaitMs);
+        final ResponseCallbackWrapper responseWrapper =
+                (ResponseCallbackWrapper) future.get(maxWaitMs + 1000, TimeUnit.MILLISECONDS);
+        try {
+            AbstractResponse abstractResponse = responseWrapper.getResponse();
+            assertTrue(abstractResponse instanceof FetchResponse);
+            final FetchResponse response = (FetchResponse) abstractResponse;
+            assertEquals(response.error(), Errors.NONE);
+            final long endTime = System.currentTimeMillis();
+            log.info("Take {} ms to process FETCH request", endTime - startTime);
+            assertTrue(endTime - startTime <= maxWaitMs);
+        } finally {
+            responseWrapper.responseComplete();
+        }
 
         Long waitingFetchesTriggered = kafkaRequestHandler.getRequestStats().getWaitingFetchesTriggered().get();
         assertEquals((long) waitingFetchesTriggered, 1);


### PR DESCRIPTION
https://github.com/Denovo1998/starlight-for-kafka/actions/runs/20877709389?pr=1

### Motivation

ResponseCallbackWrapper is used to run cleanup logic after a response is written to the network channel. When KafkaCommandDecoder fails to convert a response to ByteBuf, we currently send an error response but never invoke the wrapper’s completion callback, which can leave cleanup logic unexecuted and potentially leak in-flight request state. This PR ensures the callback is completed on the failure path as well, and aligns the related fetch test to always complete the wrapper after inspection.

### Modifications

- Call ResponseCallbackWrapper#responseComplete() when responseToByteBuf throws, before sending an error response.
- Update KafkaApisTest#testFetchMinBytesSingleConsumer to always invoke responseComplete() in a finally block after asserting on the wrapped response.
