### PR TITLE
AS-4628: Updated kotlin version to 2.1.0 to fix CVE-2020-29582

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <maven-jacoco-plugin.version>0.8.8</maven-jacoco-plugin.version>
     <kaml.version>0.104.0</kaml.version>
     <kotlinx-serialization-core.version>1.5.0</kotlinx-serialization-core.version>
-    <kotlin.version>1.8.10</kotlin.version>
+    <kotlin.version>2.1.0</kotlin.version>
     <org-json.version>20231013</org-json.version>
     <netty.version>4.1.135.Final</netty.version>
     <zookeeper.version>3.9.5</zookeeper.version>


### PR DESCRIPTION
https://datastax.jira.com/browse/AS-4628